### PR TITLE
Add Assertion<T>.isSameInstanceAs

### DIFF
--- a/strikt-core/src/main/kotlin/strikt/assertions/Any.kt
+++ b/strikt-core/src/main/kotlin/strikt/assertions/Any.kt
@@ -78,7 +78,7 @@ fun <T> Assertion<T>.isNotEqualTo(expected: Any?): Assertion<T> =
  * @param expected the expected instance.
  */
 fun <T> Assertion<T>.isSameInstanceAs(expected: Any?): Assertion<T> =
-  assert("is not the same instance as %s", expected) {
+  assert("is the same instance as %s", expected) {
     when {
       subject === expected -> pass()
       else                 -> fail()

--- a/strikt-core/src/main/kotlin/strikt/assertions/Any.kt
+++ b/strikt-core/src/main/kotlin/strikt/assertions/Any.kt
@@ -80,8 +80,6 @@ fun <T> Assertion<T>.isNotEqualTo(expected: Any?): Assertion<T> =
 fun <T> Assertion<T>.isSameInstanceAs(expected: Any?): Assertion<T> =
   assert("is not the same instance as %s", expected) {
     when {
-      subject == null      -> fail()
-      expected == null     -> fail()
       subject === expected -> pass()
       else                 -> fail()
     }

--- a/strikt-core/src/main/kotlin/strikt/assertions/Any.kt
+++ b/strikt-core/src/main/kotlin/strikt/assertions/Any.kt
@@ -70,3 +70,19 @@ fun <T> Assertion<T>.isNotEqualTo(expected: Any?): Assertion<T> =
       else     -> pass()
     }
   }
+
+/**
+ * Asserts that the subject is the same instance as [expected] according to the standard
+ * Kotlin `===` operator.
+ *
+ * @param expected the expected instance.
+ */
+fun <T> Assertion<T>.isSameInstanceAs(expected: Any?): Assertion<T> =
+  assert("is not the same instance as %s", expected) {
+    when {
+      subject == null      -> fail()
+      expected == null     -> fail()
+      subject === expected -> pass()
+      else                 -> fail()
+    }
+  }

--- a/strikt-core/src/test/kotlin/strikt/assertions/AnyAssertions.kt
+++ b/strikt-core/src/test/kotlin/strikt/assertions/AnyAssertions.kt
@@ -146,7 +146,6 @@ internal object AnyAssertions : Spek({
         Pair(listOf("covfefe"), listOf("covfefe")),
         Pair(null, listOf("covfefe")),
         Pair(listOf("covfefe"), null),
-        Pair(null, null),
         Pair(1, 1L)
       ).forEach { (subject, expected) ->
         it("fails $subject is not the same instance as $expected") {
@@ -159,6 +158,7 @@ internal object AnyAssertions : Spek({
       sequenceOf(
         Pair("covfefe", "covfefe"),
         Pair(1L, 1L),
+        Pair(null, null),
         listOf("covfefe").let { Pair(it, it) }
       ).forEach { (subject, expected) ->
         it("succeeds $subject is the same instance as $expected") {

--- a/strikt-core/src/test/kotlin/strikt/assertions/AnyAssertions.kt
+++ b/strikt-core/src/test/kotlin/strikt/assertions/AnyAssertions.kt
@@ -139,5 +139,32 @@ internal object AnyAssertions : Spek({
         }
       }
     }
+
+    describe("isSameInstanceAs assertion") {
+
+      sequenceOf(
+        Pair(listOf("covfefe"), listOf("covfefe")),
+        Pair(null, listOf("covfefe")),
+        Pair(listOf("covfefe"), null),
+        Pair(null, null),
+        Pair(1, 1L)
+      ).forEach { (subject, expected) ->
+        it("fails $subject is not the same instance as $expected") {
+          fails {
+            expect(subject).isSameInstanceAs(expected)
+          }
+        }
+      }
+
+      sequenceOf(
+        Pair("covfefe", "covfefe"),
+        Pair(1L, 1L),
+        listOf("covfefe").let { Pair(it, it) }
+      ).forEach { (subject, expected) ->
+        it("succeeds $subject is the same instance as $expected") {
+          expect(subject).isSameInstanceAs(expected)
+        }
+      }
+    }
   }
 })


### PR DESCRIPTION
Asserting that the subject is the same instance according to the standard Kotlin `===` operator.

I'm wondering if `isNotSameInstanceAs` assertion should also be added, for symmetry with `isEqualTo`/`isNotEqualTo`.