### PR TITLE
Use `it` instead of receiver in `map`

### DIFF
--- a/strikt-core/src/main/kotlin/strikt/api/Assertion.kt
+++ b/strikt-core/src/main/kotlin/strikt/api/Assertion.kt
@@ -165,7 +165,7 @@ interface Assertion {
      * @return an assertion whose subject is the value returned by [function].
      */
     // TODO: not sure about this name, it's fundamentally similar to Kotlin's run. Also it might be nice to have a dedicated `map` for Assertion<Iterable>.
-    fun <R> map(function: T.() -> R): DescribeableBuilder<R> =
+    fun <R> map(function: (T) -> R): DescribeableBuilder<R> =
       when (function) {
         is CallableReference -> map(".${function.propertyName} %s", function)
         else -> map("%s", function)
@@ -180,7 +180,7 @@ interface Assertion {
      * @param function a lambda whose receiver is the current assertion subject.
      * @return an assertion whose subject is the value returned by [function].
      */
-    fun <R> map(description: String, function: T.() -> R): DescribeableBuilder<R>
+    fun <R> map(description: String, function: (T) -> R): DescribeableBuilder<R>
 
     /**
      * Reverses any assertions chained after this method.

--- a/strikt-core/src/main/kotlin/strikt/assertions/Iterable.kt
+++ b/strikt-core/src/main/kotlin/strikt/assertions/Iterable.kt
@@ -9,7 +9,7 @@ import strikt.api.Assertion.Builder
  * @see Iterable.first
  */
 fun <T : Iterable<E>, E> Builder<T>.first(): Builder<E> =
-  map("first element %s") { first() }
+  map("first element %s") { it.first() }
 
 /**
  * Maps this assertion to an assertion over the last element in the subject
@@ -18,15 +18,15 @@ fun <T : Iterable<E>, E> Builder<T>.first(): Builder<E> =
  * @see Iterable.last
  */
 fun <T : Iterable<E>, E> Builder<T>.last(): Builder<E> =
-  map("last element %s") { last() }
+  map("last element %s") { it.last() }
 
 /**
  * Asserts that all elements of the subject pass the assertions in [predicate].
  */
 fun <T : Iterable<E>, E> Builder<T>.all(predicate: Builder<E>.() -> Unit): Builder<T> =
   compose("all elements match:") { subject ->
-    subject.forEach {
-      map { it }.apply(predicate)
+    subject.forEach { element ->
+      map { element }.apply(predicate)
     }
   } then {
     if (allPassed) pass() else fail()
@@ -38,8 +38,8 @@ fun <T : Iterable<E>, E> Builder<T>.all(predicate: Builder<E>.() -> Unit): Build
  */
 fun <T : Iterable<E>, E> Builder<T>.any(predicate: Builder<E>.() -> Unit): Builder<T> =
   compose("at least one element matches:") { subject ->
-    subject.forEach {
-      map { it }.apply(predicate)
+    subject.forEach { element ->
+      map { element }.apply(predicate)
     }
   } then {
     if (anyPassed) pass() else fail()
@@ -50,8 +50,8 @@ fun <T : Iterable<E>, E> Builder<T>.any(predicate: Builder<E>.() -> Unit): Build
  */
 fun <T : Iterable<E>, E> Builder<T>.none(predicate: Builder<E>.() -> Unit): Builder<T> =
   compose("no elements match:") { subject ->
-    subject.forEach {
-      map { it }.apply(predicate)
+    subject.forEach { element ->
+      map { element }.apply(predicate)
     }
   } then {
     if (allFailed) pass() else fail()

--- a/strikt-core/src/main/kotlin/strikt/assertions/List.kt
+++ b/strikt-core/src/main/kotlin/strikt/assertions/List.kt
@@ -7,11 +7,13 @@ import strikt.api.Assertion.Builder
  * subject list.
  */
 operator fun <T : List<E>, E> Builder<T>.get(i: Int): Builder<E> =
-  map("element [$i] %s") { get(i) }
+  map("element [$i] %s") { it[i] }
 
 /**
  * Maps this assertion to an assertion on the elements at the sub-list
  * represented by [range] in the subject list.
  */
 operator fun <T : List<E>, E> Builder<T>.get(range: IntRange): Builder<List<E>> =
-  map("elements [$range] %s") { subList(range.first, range.last + 1) }
+  map("elements [$range] %s") {
+    it.subList(range.first, range.last + 1)
+  }

--- a/strikt-core/src/main/kotlin/strikt/assertions/Map.kt
+++ b/strikt-core/src/main/kotlin/strikt/assertions/Map.kt
@@ -17,7 +17,7 @@ fun <T : Map<K, V>, K, V> Builder<T>.isEmpty() =
  * exists in the subject map.
  */
 operator fun <T : Map<K, V>, K, V> Builder<T>.get(key: K): Builder<V?> =
-  map("entry [${formatValue(key)}] %s") { get(key) }
+  map("entry [${formatValue(key)}] %s") { it[key] }
 
 /**
  * Asserts that the subject map contains an entry indexed by [key]. Depending on

--- a/strikt-core/src/main/kotlin/strikt/assertions/TemporalAccessor.kt
+++ b/strikt-core/src/main/kotlin/strikt/assertions/TemporalAccessor.kt
@@ -62,7 +62,7 @@ fun <T : TemporalAccessor> Assertion.Builder<T>.isAfter(expected: TemporalAccess
  * @see TemporalAccessor.get
  */
 fun <T : TemporalAccessor> Assertion.Builder<T>.get(field: TemporalField): Assertion.Builder<Int> =
-  map { get(field) }
+  map { it.get(field) }
 
 /**
  * Maps an assertion on the subject to an assertion on the value of the
@@ -74,4 +74,4 @@ fun <T : TemporalAccessor> Assertion.Builder<T>.get(field: TemporalField): Asser
  * @see TemporalAccessor.getLong
  */
 fun <T : TemporalAccessor> Assertion.Builder<T>.getLong(field: TemporalField): Assertion.Builder<Long> =
-  map { getLong(field) }
+  map { it.getLong(field) }

--- a/strikt-core/src/main/kotlin/strikt/internal/AssertionBuilder.kt
+++ b/strikt-core/src/main/kotlin/strikt/internal/AssertionBuilder.kt
@@ -110,8 +110,8 @@ internal class AssertionBuilder<T>(
     }
   }
 
-  override fun <R> map(description: String, function: T.() -> R): DescribeableBuilder<R> =
-    context.subject.function()
+  override fun <R> map(description: String, function: (T) -> R): DescribeableBuilder<R> =
+    function(context.subject)
       .let { mappedValue ->
         AssertionBuilder(
           AssertionSubject(context, mappedValue, description),

--- a/strikt-core/src/test/kotlin/strikt/Chained.kt
+++ b/strikt-core/src/test/kotlin/strikt/Chained.kt
@@ -70,7 +70,7 @@ internal class Chained {
       assertEquals(expected, error.message)
       expect(error)
         .isA<CompoundAssertionFailure>()
-        .map { failures }
+        .map { it.failures }
         .hasSize(1)
         .first()
         .isA<AtomicAssertionFailure>()

--- a/strikt-core/src/test/kotlin/strikt/Mapping.kt
+++ b/strikt-core/src/test/kotlin/strikt/Mapping.kt
@@ -80,8 +80,8 @@ internal class Mapping {
     @Test
     fun `can map with a closure`() {
       expect(subject) {
-        map { name }.isEqualTo("David")
-        map { birthDate.year }.isEqualTo(1947)
+        map { it.name }.isEqualTo("David")
+        map { it.birthDate.year }.isEqualTo(1947)
       }
     }
 
@@ -96,8 +96,8 @@ internal class Mapping {
     @Test
     fun `closures can call methods`() {
       expect(subject) {
-        map { name.toUpperCase() }.isEqualTo("DAVID")
-        map { birthDate.plusYears(69).plusDays(2) }
+        map { it.name.toUpperCase() }.isEqualTo("DAVID")
+        map { it.birthDate.plusYears(69).plusDays(2) }
           .isEqualTo(LocalDate.of(2016, 1, 10))
       }
     }
@@ -106,8 +106,8 @@ internal class Mapping {
     fun `can be described`() {
       fails {
         expect(subject) {
-          map { name }.describedAs("name").isEqualTo("Ziggy")
-          map { birthDate.year }.describedAs("birth year").isEqualTo(1971)
+          map { it.name }.describedAs("name").isEqualTo("Ziggy")
+          map { it.birthDate.year }.describedAs("birth year").isEqualTo(1971)
         }
       }.let { e ->
         assertEquals(


### PR DESCRIPTION
Consistency with new behavior of `assert` and `compose`.

See #71 
