### PR TITLE
run junit tests in parallel in the IDE

### DIFF
--- a/gradle/junit.gradle
+++ b/gradle/junit.gradle
@@ -4,5 +4,6 @@ dependencies {
 }
 
 test {
+  systemProperty 'junit.jupiter.execution.parallel.enabled', 'false'
   useJUnitPlatform()
 }

--- a/strikt-core/src/test/resources/junit-platform.properties
+++ b/strikt-core/src/test/resources/junit-platform.properties
@@ -1,0 +1,2 @@
+# suppress inspection "UnusedProperty" for whole file
+junit.jupiter.execution.parallel.enabled=true


### PR DESCRIPTION
this speeds up the test run from 1.5s to 300ms on my slow macbook. 

in gradle its disabled because the junit parallel runner makes problems there. i tried gradle's native multithreading, but that made the tests slower, i think it forks new vms.