### PR TITLE
Adds Collection Sorted assertion for #124

### DIFF
--- a/strikt-core/src/main/kotlin/strikt/assertions/Collection.kt
+++ b/strikt-core/src/main/kotlin/strikt/assertions/Collection.kt
@@ -26,6 +26,18 @@ fun <T : Collection<E>, E> Builder<T>.isNotEmpty(): Builder<T> =
   assertThat("is not empty", Collection<E>::isNotEmpty)
 
 /**
+ * Asserts that the subject collection is sorted according to the Comparator. Empty collections are considered sorted.
+ */
+fun <T : Collection<E>, E> Builder<T>.isSorted(comparator: Comparator<E>) =
+  assert("is sorted") { actual ->
+    for (index in 0 until (actual.size - 1)) {
+      if (comparator.compare(actual.elementAt(index), actual.elementAt(index + 1)) > 0)
+        fail(actual, "${actual.elementAt(index)} is greater than ${actual.elementAt(index + 1)}")
+    }
+    pass()
+  }
+
+/**
  * Maps an assertion on a collection to an assertion on its size.
  *
  * @see Collection.size

--- a/strikt-core/src/test/kotlin/strikt/assertions/CollectionAssertions.kt
+++ b/strikt-core/src/test/kotlin/strikt/assertions/CollectionAssertions.kt
@@ -63,4 +63,71 @@ internal object CollectionAssertions {
       }
     }
   }
+
+  @TestFactory
+  fun isSortedOnAny() = assertionTests<Collection<Any?>> {
+    context("an empty collection subject") {
+      fixture { expectThat(emptyList()) }
+
+      test("the assertion passes") {
+        isSorted(Comparator.comparingInt(Any::hashCode))
+      }
+    }
+  }
+
+  @TestFactory
+  fun isSortedOnString() = assertionTests<Collection<String?>> {
+    context("an non-empty simple value collection subject") {
+      fixture { expectThat(listOf("catflap", "marzipan", "rubber")) }
+
+      test("the assertion passes") {
+        isSorted(Comparator.naturalOrder<String>())
+      }
+
+      test("fails if the subject is not sorted according to the comparator") {
+        assertThrows<AssertionError> {
+          isSorted(Comparator.naturalOrder<String>().reversed())
+        }
+      }
+    }
+
+    context("an non-empty simple value collection subject containing null value") {
+      fixture { expectThat(listOf("catflap", "marzipan", null)) }
+
+      test("the assertion passes if the Null value is handled through the Comparator instance") {
+        isSorted(Comparator.nullsLast(Comparator.naturalOrder<String>()))
+      }
+
+      test("fails with NPE if the Null value isn't handled through the Comparator instances") {
+        assertThrows<NullPointerException> {
+          isSorted(Comparator.naturalOrder<String>())
+        }
+      }
+    }
+  }
+
+  @TestFactory
+  fun isSortedOnNonComparable() = assertionTests<Collection<Collection<String>?>> {
+    context("an non-empty non Comparable value collection subject") {
+      fixture {
+        expectThat(
+          listOf(
+            listOf("catflap"),
+            listOf("marzipan", "persipan"),
+            listOf("rubberplan", "rubber bush", "rubber tree")
+          )
+        )
+      }
+
+      test("the assertion passes") {
+        isSorted(Comparator.comparing(Collection<String>::size))
+      }
+
+      test("fails if the subject is not sorted according to the comparator") {
+        assertThrows<AssertionError> {
+          isSorted(Comparator.comparing(Collection<String>::size).reversed())
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
This PR is intended to solve #124 

[Comparator](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-comparator/index.html) interface is a Kotlin common one so there should be no issues if there will be a future multiplatform support. Tests use the JVM implementation but tests are JUnit Jupiter based anyway.

Handling of Nullable elements would be delegated to the user and an empty collection is considered Sorted.