### PR TITLE
limit pitest to 4 threads and 512mb per thread on circeci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,18 +64,18 @@ jobs:
       - checkout
       - run: ./gradlew :strikt-core:dependencies :strikt-java-time:dependencies :strikt-protobuf:dependencies :site:dependencies --write-locks; if [ `git status --porcelain | wc -l` -ne 0 ]; then ./gradlew build && git commit -am "Upgraded dependencies" --author CircleCI && git push --repo=https://circleci:${GITHUB_OAUTH_TOKEN}@github.com/robfletcher/strikt.git; fi
 
-#  pitest:
-#    <<: *defaults
-#    steps:
-#      - checkout
-#      - run: ./gradlew pitest
-#      - run:
-#          name: Archive test results
-#          command: |
-#            find . -type d -regex ".*/build/reports/pitest" -exec cp -R {} /tmp/ \;
-#          when: always
-#      - store_artifacts:
-#          path: /tmp/pitest
+  pitest:
+    <<: *defaults
+    steps:
+      - checkout
+      - run: ./gradlew pitest
+      - run:
+          name: Archive test results
+          command: |
+            find . -type d -regex ".*/build/reports/pitest" -exec cp -R {} /tmp/ \;
+          when: always
+      - store_artifacts:
+          path: /tmp/pitest
 
 workflows:
   version: 2
@@ -105,11 +105,11 @@ workflows:
               ignore: gh-pages
             tags:
               only: /.*/
-#      - pitest:
-#          requires:
-#            - build-java8
-#            - build-java9
-#            - build-java10
+      - pitest:
+          requires:
+            - build-java8
+            - build-java9
+            - build-java10
 #          filters:
 #            branches:
 #              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,9 +110,9 @@ workflows:
             - build-java8
             - build-java9
             - build-java10
-#          filters:
-#            branches:
-#              only: master
+          filters:
+            branches:
+              only: master
       - release:
           requires:
             - build-java8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - run: ./gradlew pitest
+      - run: PITEST_THREADS=4 ./gradlew pitest
       - run:
           name: Archive test results
           command: |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
-@file:Suppress("UNUSED_VARIABLE")
+@file:Suppress("UNUSED_VARIABLE", "UnstableApiUsage")
 
 import info.solidsoft.gradle.pitest.PitestPluginExtension
 import org.gradle.api.JavaVersion.VERSION_1_8

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,7 +89,8 @@ subprojects {
         targetClasses = setOf("strikt.*")  //by default "${project.group}.*"
         targetTests = setOf("strikt.**.*")
         pitestVersion = "1.4.2"
-        threads = 4
+        threads = System.getenv("PITEST_THREADS")?.toInt() ?:
+          Runtime.getRuntime().availableProcessors()
         outputFormats = setOf("XML", "HTML")
       }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -88,7 +88,7 @@ subprojects {
         targetClasses = setOf("strikt.*")  //by default "${project.group}.*"
         targetTests = setOf("strikt.**.*")
         pitestVersion = "1.4.2"
-        threads = Runtime.getRuntime().availableProcessors()
+        threads = 2
         outputFormats = setOf("XML", "HTML")
       }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,13 +82,14 @@ subprojects {
 
     plugins.withId("info.solidsoft.pitest") {
       configure<PitestPluginExtension> {
+        jvmArgs = listOf("-Xmx512m")
         testPlugin = "junit5"
         avoidCallsTo = setOf("kotlin.jvm.internal")
         mutators = setOf("NEW_DEFAULTS")
         targetClasses = setOf("strikt.*")  //by default "${project.group}.*"
         targetTests = setOf("strikt.**.*")
         pitestVersion = "1.4.2"
-        threads = 2
+        threads = 4
         outputFormats = setOf("XML", "HTML")
       }
     }


### PR DESCRIPTION
it seems the problem on circleci was too high memory usage. thats why a default circleci config file always contains the `JVM_OPTS: -Xmx3200m`. but in the case of pitest we start multiple threads so we need a much lower per vm limit
also limits the threads to 4, because i read that circleci reports too many cpu cores. locally we still use autodetection. 