### PR TITLE
Add `not` assertion overload that takes a block

### DIFF
--- a/strikt-core/src/main/kotlin/strikt/api/Assertion.kt
+++ b/strikt-core/src/main/kotlin/strikt/api/Assertion.kt
@@ -284,6 +284,14 @@ interface Assertion {
     fun not(): Builder<T>
 
     /**
+     * Evaluates a block of assertions on the current subject by executing them in reverse.
+     *
+     * @param assertions the assertions to evaluate in reverse
+     * @see not
+     */
+    fun not(assertions: Builder<T>.() -> Unit): Builder<T>
+
+    /**
      * Evaluates a block of assertions on the current subject.
      *
      * The main use for this method is after [strikt.assertions.isNotNull] or

--- a/strikt-core/src/main/kotlin/strikt/internal/AssertionBuilder.kt
+++ b/strikt-core/src/main/kotlin/strikt/internal/AssertionBuilder.kt
@@ -25,6 +25,12 @@ internal class AssertionBuilder<T>(
     return this
   }
 
+  override fun not(assertions: Builder<T>.() -> Unit): Assertion.Builder<T> {
+    AssertionBuilder(context, AssertionStrategy.Negating(AssertionStrategy.Collecting)).apply(assertions)
+    strategy.evaluate(context)
+    return this
+  }
+
   override fun assert(
     description: String,
     expected: Any?,

--- a/strikt-core/src/test/kotlin/strikt/Block.kt
+++ b/strikt-core/src/test/kotlin/strikt/Block.kt
@@ -57,6 +57,28 @@ internal class Block {
   }
 
   @Test
+  fun `assertions in a block can be negated in a not block`() {
+    assertThrows<AssertionError> {
+      val subject: Any? = "fnord"
+      expectThat(subject).not {
+        isNull()
+        isNotNull()
+        isA<String>()
+        isA<Number>()
+      }
+    }.let { error ->
+      val expected = """
+        |▼ Expect that "fnord":
+        |  ✓ is not null
+        |  ✗ is null
+        |  ✗ is not an instance of java.lang.String
+        |  ✓ is not an instance of java.lang.Number"""
+        .trimMargin()
+      assertEquals(expected, error.message)
+    }
+  }
+
+  @Test
   fun `an and block can be negated`() {
     val subject: Any? = "fnord"
     expectThat(subject).not().and {


### PR DESCRIPTION
The current patterns that can be applied with the existing methods are:

```kotlin
expectThat(thing).not().and {
  isNull()
  someAssertion()
}
```

The block works as expected, but a possibly unintended side effect is if any more assertions are chained after the `and {}` block they are also inverted from the `not()`.

Another way to do this is use the `not()` builder from inside the `and {}` block:

```kotlin
expectThat(thing).and {
  not().isNull()
  not().someAssertion()
}
```

This works as expected but is fairly verbose.
This method is useful, and also works well when mixing in other assertions.

With this new `not {}` API the `not {}` builder block combines aspects of `not()` and `and {}` while retaining the asseriton strategy after the block.

```kotlin
expectThat(thing).not {
  isNull()
  someAssertion()
}
```

issue https://github.com/robfletcher/strikt/issues/139