### PR TITLE
Ensure assertion chains always fail-fast

### DIFF
--- a/strikt-core/src/main/kotlin/strikt/api/CompoundAssertion.kt
+++ b/strikt-core/src/main/kotlin/strikt/api/CompoundAssertion.kt
@@ -12,6 +12,10 @@ package strikt.api
  * `false`.
  * @property anyFailed `true` if at least one composed assertion failed,
  * otherwise `false`.
+ * @property passedCount the number of composed assertions whose status is
+ * [strikt.api.Status.Passed].
+ * @property failedCount the number of composed assertions whose status is
+ * [strikt.api.Status.Failed].
  */
 interface CompoundAssertion : Assertion {
   val anyFailed: Boolean

--- a/strikt-core/src/main/kotlin/strikt/api/Expect.kt
+++ b/strikt-core/src/main/kotlin/strikt/api/Expect.kt
@@ -4,7 +4,8 @@ import kotlinx.coroutines.runBlocking
 import strikt.api.Assertion.Builder
 import strikt.assertions.throws
 import strikt.internal.AssertionBuilder
-import strikt.internal.AssertionStrategy
+import strikt.internal.AssertionStrategy.Collecting
+import strikt.internal.AssertionStrategy.Throwing
 import strikt.internal.AssertionSubject
 
 /**
@@ -18,7 +19,7 @@ fun expect(block: suspend ExpectationBuilder.() -> Unit) {
     override fun <T> that(subject: T): DescribeableBuilder<T> =
       AssertionSubject(subject)
         .also { subjects.add(it) }
-        .let { AssertionBuilder(it, AssertionStrategy.Collecting) }
+        .let { AssertionBuilder(it, Collecting) }
 
     override fun <T> that(
       subject: T,
@@ -31,7 +32,7 @@ fun expect(block: suspend ExpectationBuilder.() -> Unit) {
       }
     }
     .let {
-      AssertionStrategy.Throwing.evaluate(subjects)
+      Throwing.evaluate(subjects)
     }
 }
 
@@ -43,7 +44,7 @@ fun expect(block: suspend ExpectationBuilder.() -> Unit) {
  * @return an assertion for [subject].
  */
 fun <T> expectThat(subject: T): DescribeableBuilder<T> =
-  AssertionBuilder(AssertionSubject(subject), AssertionStrategy.Throwing)
+  AssertionBuilder(AssertionSubject(subject), Throwing)
 
 /**
  * Evaluate a block of assertions over [subject].
@@ -59,10 +60,10 @@ fun <T> expectThat(
   block: Builder<T>.() -> Unit
 ): DescribeableBuilder<T> =
   AssertionSubject(subject).let { context ->
-    AssertionBuilder(context, AssertionStrategy.Collecting)
+    AssertionBuilder(context, Collecting)
       .apply {
         block()
-        AssertionStrategy.Throwing.evaluate(context)
+        Throwing.evaluate(context)
       }
   }
 

--- a/strikt-core/src/main/kotlin/strikt/assertions/Iterable.kt
+++ b/strikt-core/src/main/kotlin/strikt/assertions/Iterable.kt
@@ -274,10 +274,10 @@ fun <T : Iterable<E>, E> Builder<T>.containsExactly(elements: Collection<E>): Bu
     val original = subject.toList()
     val remaining = subject.toMutableList()
     elements.forEachIndexed { i, element ->
-      assert("contains %s", element) { _ ->
+      assert("contains %s", element) {
         if (remaining.remove(element)) {
           pass()
-          assert("…at index $i", element) { _ ->
+          assert("…at index $i", element) {
             if (original[i] == element) {
               pass()
             } else {
@@ -289,7 +289,7 @@ fun <T : Iterable<E>, E> Builder<T>.containsExactly(elements: Collection<E>): Bu
         }
       }
     }
-    assert("contains no further elements", emptyList<E>()) { _ ->
+    assert("contains no further elements", emptyList<E>()) {
       if (remaining.isEmpty()) {
         pass()
       } else {
@@ -322,7 +322,7 @@ fun <T : Iterable<E>, E> Builder<T>.containsExactlyInAnyOrder(elements: Collecti
   ) { subject ->
     val remaining = subject.toMutableList()
     elements.forEach { element ->
-      assert("contains %s", element) { _ ->
+      assert("contains %s", element) {
         if (remaining.remove(element)) {
           pass()
         } else {
@@ -330,7 +330,7 @@ fun <T : Iterable<E>, E> Builder<T>.containsExactlyInAnyOrder(elements: Collecti
         }
       }
     }
-    assert("contains no further elements", emptyList<E>()) { _ ->
+    assert("contains no further elements", emptyList<E>()) {
       if (remaining.isEmpty()) {
         pass()
       } else {

--- a/strikt-core/src/main/kotlin/strikt/internal/AssertionBuilder.kt
+++ b/strikt-core/src/main/kotlin/strikt/internal/AssertionBuilder.kt
@@ -72,17 +72,16 @@ internal class AssertionBuilder<T>(
   override fun <R> get(
     description: String,
     function: (T) -> R
-  ): DescribeableBuilder<R> {
+  ): DescribeableBuilder<R> =
     if (context.allowChain) {
       val mappedValue = function(context.subject)
-      return AssertionBuilder(
+      AssertionBuilder(
         AssertionSubject(context, mappedValue, description),
         strategy
       )
     } else {
-      return this as AssertionBuilder<R> // TODO: no, this is a lie
+      this as AssertionBuilder<R> // TODO: no, this is a lie
     }
-  }
 
   override fun not(): Builder<T> = AssertionBuilder(
     context,

--- a/strikt-core/src/main/kotlin/strikt/internal/AssertionNode.kt
+++ b/strikt-core/src/main/kotlin/strikt/internal/AssertionNode.kt
@@ -149,7 +149,8 @@ internal abstract class AtomicAssertionNode<S>(
     get() = parent.root
 
   init {
-    parent.also { it.append(this) }
+    @Suppress("LeakingThis")
+    parent.append(this)
   }
 }
 
@@ -166,6 +167,7 @@ internal abstract class CompoundAssertionNode<S>(
     get() = parent.root
 
   init {
+    @Suppress("LeakingThis")
     parent.append(this)
   }
 

--- a/strikt-core/src/main/kotlin/strikt/internal/AssertionStrategy.kt
+++ b/strikt-core/src/main/kotlin/strikt/internal/AssertionStrategy.kt
@@ -124,10 +124,10 @@ internal sealed class AssertionStrategy {
       return children
         .filter { it.status is Failed }
         .map { node ->
-          if (node is AssertionChain) {
-            node.children.first { it.status is Failed }
-          } else {
-            node
+          when (node) {
+            is AssertionChain -> node.children.first { it.status is Failed }
+            is AssertionChainedGroup -> node.children.first { it.status is Failed }
+            else -> node
           }
         }
     }

--- a/strikt-core/src/main/kotlin/strikt/internal/AssertionStrategy.kt
+++ b/strikt-core/src/main/kotlin/strikt/internal/AssertionStrategy.kt
@@ -106,9 +106,7 @@ internal sealed class AssertionStrategy {
       if (tree.status is Failed) {
         throw CompoundAssertionFailure(
           tree.root.writeToString(),
-          tree
-            .children
-            .filter { it.status is Failed }
+          tree.findFailureNodes()
             .map {
               createAssertionFailedError(
                 it.writePartialToString(),
@@ -117,6 +115,21 @@ internal sealed class AssertionStrategy {
             }
         )
       }
+    }
+
+    /**
+     * Find the failing leaf nodes in an assertion result graph.
+     */
+    private fun AssertionGroup<*>.findFailureNodes(): List<AssertionNode<*>> {
+      return children
+        .filter { it.status is Failed }
+        .map { node ->
+          if (node is AssertionChain) {
+            node.children.first { it.status is Failed }
+          } else {
+            node
+          }
+        }
     }
 
     override fun evaluate(trees: Collection<AssertionGroup<*>>) {

--- a/strikt-core/src/main/kotlin/strikt/internal/AssertionStrategy.kt
+++ b/strikt-core/src/main/kotlin/strikt/internal/AssertionStrategy.kt
@@ -123,7 +123,12 @@ internal sealed class AssertionStrategy {
       if (trees.any { it.status is Status.Failed }) {
         val failures = trees
           .filter { it.status is Failed }
-          .map { createAssertionFailedError(it.writeToString(), it.status as Failed) }
+          .map {
+            createAssertionFailedError(
+              it.writeToString(),
+              it.status as Failed
+            )
+          }
         throw CompoundAssertionFailure(trees.writeToString(), failures)
       }
     }

--- a/strikt-core/src/main/kotlin/strikt/internal/reporting/DefaultResultWriter.kt
+++ b/strikt-core/src/main/kotlin/strikt/internal/reporting/DefaultResultWriter.kt
@@ -3,6 +3,7 @@ package strikt.internal.reporting
 import strikt.api.Status.Failed
 import strikt.api.Status.Passed
 import strikt.api.Status.Pending
+import strikt.internal.AssertionChain
 import strikt.internal.AssertionGroup
 import strikt.internal.AssertionNode
 import strikt.internal.AssertionResult
@@ -48,7 +49,11 @@ internal open class DefaultResultWriter : ResultWriter {
     if (node is AssertionGroup<*>) {
       node.children.forEach {
         writeLineEnd(writer, it)
-        writeIndented(writer, it, indent + 1)
+        writeIndented(
+          writer,
+          it,
+          if (node is AssertionChain) indent else indent + 1
+        )
       }
     }
   }
@@ -109,11 +114,15 @@ internal open class DefaultResultWriter : ResultWriter {
     node: AssertionNode<*>,
     indent: Int
   ) {
-    writer.append("".padStart(2 * indent))
+    if (node !is AssertionChain) {
+      writer.append("".padStart(2 * indent))
+    }
   }
 
   protected open fun writeLineEnd(writer: Appendable, node: AssertionNode<*>) {
-    writer.append(EOL)
+    if (node !is AssertionChain) {
+      writer.append(EOL)
+    }
   }
 
   protected open fun writeStatusIcon(

--- a/strikt-core/src/main/kotlin/strikt/internal/reporting/DefaultResultWriter.kt
+++ b/strikt-core/src/main/kotlin/strikt/internal/reporting/DefaultResultWriter.kt
@@ -35,7 +35,9 @@ internal open class DefaultResultWriter : ResultWriter {
 
   private fun <S> AssertionNode<S>.addAncestorsTo(tree: MutableList<AssertionNode<*>>) {
     parent?.also {
-      tree.add(0, it)
+      if (it !is AssertionChain) {
+        tree.add(0, it)
+      }
       it.addAncestorsTo(tree)
     }
   }

--- a/strikt-core/src/main/kotlin/strikt/internal/reporting/DefaultResultWriter.kt
+++ b/strikt-core/src/main/kotlin/strikt/internal/reporting/DefaultResultWriter.kt
@@ -3,11 +3,11 @@ package strikt.internal.reporting
 import strikt.api.Status.Failed
 import strikt.api.Status.Passed
 import strikt.api.Status.Pending
-import strikt.internal.AssertionChain
 import strikt.internal.AssertionGroup
 import strikt.internal.AssertionNode
 import strikt.internal.AssertionResult
 import strikt.internal.AssertionSubject
+import strikt.internal.DescribedNode
 
 internal open class DefaultResultWriter : ResultWriter {
 
@@ -35,7 +35,7 @@ internal open class DefaultResultWriter : ResultWriter {
 
   private fun <S> AssertionNode<S>.addAncestorsTo(tree: MutableList<AssertionNode<*>>) {
     parent?.also {
-      if (it !is AssertionChain) {
+      if (it is DescribedNode<*>) {
         tree.add(0, it)
       }
       it.addAncestorsTo(tree)
@@ -54,7 +54,7 @@ internal open class DefaultResultWriter : ResultWriter {
         writeIndented(
           writer,
           it,
-          if (node is AssertionChain) indent else indent + 1
+          if (node is DescribedNode) indent + 1 else indent
         )
       }
     }
@@ -116,13 +116,13 @@ internal open class DefaultResultWriter : ResultWriter {
     node: AssertionNode<*>,
     indent: Int
   ) {
-    if (node !is AssertionChain) {
+    if (node is DescribedNode) {
       writer.append("".padStart(2 * indent))
     }
   }
 
   protected open fun writeLineEnd(writer: Appendable, node: AssertionNode<*>) {
-    if (node !is AssertionChain) {
+    if (node is DescribedNode) {
       writer.append(EOL)
     }
   }

--- a/strikt-core/src/test/kotlin/strikt/Block.kt
+++ b/strikt-core/src/test/kotlin/strikt/Block.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.assertThrows
 import strikt.api.expectThat
 import strikt.assertions.contains
 import strikt.assertions.isA
+import strikt.assertions.isEqualTo
 import strikt.assertions.isNotNull
 import strikt.assertions.isNull
 
@@ -29,6 +30,26 @@ internal class Block {
         |  ✓ is not null
         |  ✓ is an instance of java.lang.String
         |  ✗ is an instance of java.lang.Number : found java.lang.String"""
+        .trimMargin()
+      assertEquals(expected, error.message)
+    }
+  }
+
+  @Test
+  fun `chains inside of blocks break on the first failure`() {
+    assertThrows<AssertionError> {
+      val subject: Any? = "fnord"
+      expectThat(subject) {
+        isNotNull()
+        isA<Number>().isA<Long>()
+        isEqualTo("fnord")
+      }
+    }.let { error ->
+      val expected = """
+        |▼ Expect that "fnord":
+        |  ✓ is not null
+        |  ✗ is an instance of java.lang.Number : found java.lang.String
+        |  ✓ is equal to "fnord""""
         .trimMargin()
       assertEquals(expected, error.message)
     }

--- a/strikt-core/src/test/kotlin/strikt/Block.kt
+++ b/strikt-core/src/test/kotlin/strikt/Block.kt
@@ -8,6 +8,7 @@ import strikt.api.expectThat
 import strikt.assertions.contains
 import strikt.assertions.isA
 import strikt.assertions.isEqualTo
+import strikt.assertions.isGreaterThan
 import strikt.assertions.isNotNull
 import strikt.assertions.isNull
 
@@ -50,6 +51,22 @@ internal class Block {
         |  ✓ is not null
         |  ✗ is an instance of java.lang.Number : found java.lang.String
         |  ✓ is equal to "fnord""""
+        .trimMargin()
+      assertEquals(expected, error.message)
+    }
+  }
+
+  @Test
+  fun `get chained after a failing assertion is not evaluated`() {
+    assertThrows<AssertionError> {
+      val subject: Any? = "fnord"
+      expectThat(subject) {
+        isA<Int>().get("multiplied by two") { this * 2 }.isGreaterThan(1)
+      }
+    }.let { error ->
+      val expected = """
+        |▼ Expect that "fnord":
+        |  ✗ is an instance of java.lang.Integer : found java.lang.String"""
         .trimMargin()
       assertEquals(expected, error.message)
     }

--- a/strikt-core/src/test/kotlin/strikt/Chained.kt
+++ b/strikt-core/src/test/kotlin/strikt/Chained.kt
@@ -85,12 +85,13 @@ internal class Chained {
         }
     }
     assertEquals(
-      "▼ Expect that \"fnord\":\n" +
-        "  ✓ is not null\n" +
-        "  ✓ is lower case\n" +
-        "  ✓ contains \"f\"\n" +
-        "  ✓ contains \"n\"\n" +
-        "  ✗ contains \"z\" : found \"fnord\"",
+      """▼ Expect that "fnord":
+        |  ✓ is not null
+        |  ✓ is lower case
+        |  ✓ contains "f"
+        |  ✓ contains "n"
+        |  ✗ contains "z" : found "fnord""""
+        .trimMargin(),
       error.message
     )
   }

--- a/strikt-core/src/test/kotlin/strikt/Exceptions.kt
+++ b/strikt-core/src/test/kotlin/strikt/Exceptions.kt
@@ -17,6 +17,7 @@ import strikt.assertions.isLessThan
 import strikt.assertions.isNotEqualTo
 import strikt.assertions.isTrue
 import strikt.assertions.isUpperCase
+import strikt.assertions.length
 import strikt.assertions.message
 import strikt.assertions.startsWith
 import strikt.internal.opentest4j.CompoundAssertionFailure
@@ -75,7 +76,7 @@ class Exceptions {
   fun `chains involving "and" raise a single compound exception`() {
     assertThrows<AssertionError> {
       expectThat("fnord")
-        .get(String::length)
+        .length
         .isGreaterThan(0)
         .and {
           isEqualTo(1)
@@ -138,7 +139,7 @@ class Exceptions {
   fun `blocks involving "and" raise a single compound exception`() {
     assertThrows<AssertionError> {
       expectThat("fnord") {
-        get(String::length)
+        length
           .isGreaterThan(0)
           .and {
             isEqualTo(1)

--- a/strikt-core/src/test/kotlin/strikt/Exceptions.kt
+++ b/strikt-core/src/test/kotlin/strikt/Exceptions.kt
@@ -31,9 +31,10 @@ class Exceptions {
         .isA<AssertionFailedError>()
         .message
         .isEqualTo(
-            "▼ Expect that \"fnord\":\n" +
-              "  ✓ has length 5\n" +
-              "  ✗ is upper case"
+          """▼ Expect that "fnord":
+            |  ✓ has length 5
+            |  ✗ is upper case"""
+            .trimMargin()
           )
     }
   }
@@ -51,18 +52,20 @@ class Exceptions {
         .isA<CompoundAssertionFailure>()
         .and {
           message.isEqualTo(
-            "▼ Expect that \"fnord\":\n" +
-              "  ✓ has length 5\n" +
-              "  ✗ is upper case\n" +
-              "  ✓ starts with \"f\""
+            """▼ Expect that "fnord":
+              |  ✓ has length 5
+              |  ✗ is upper case
+              |  ✓ starts with "f""""
+              .trimMargin()
           )
           get { failures }
             .hasSize(1)
             .first()
             .isA<AssertionFailedError>()
             .message.isEqualTo(
-            "▼ Expect that \"fnord\":\n" +
-              "  ✗ is upper case"
+            """▼ Expect that "fnord":
+              |  ✗ is upper case"""
+              .trimMargin()
           )
         }
     }
@@ -84,12 +87,13 @@ class Exceptions {
         .isA<CompoundAssertionFailure>()
         .and {
           message.isEqualTo(
-            "▼ Expect that \"fnord\":\n" +
-              "  ▼ value of property length:\n" +
-              "    ✓ is greater than 0\n" +
-              "    ✗ is equal to 1 : found 5\n" +
-              "    ✗ is less than 2\n" +
-              "    ✗ is not equal to 5"
+            """▼ Expect that "fnord":
+              |  ▼ value of property length:
+              |    ✓ is greater than 0
+              |    ✗ is equal to 1 : found 5
+              |    ✗ is less than 2
+              |    ✗ is not equal to 5"""
+              .trimMargin()
           )
         }
         .get { failures }
@@ -99,9 +103,10 @@ class Exceptions {
             .isA<AssertionFailedError>()
             .message
             .isEqualTo(
-              "▼ Expect that \"fnord\":\n" +
-                "  ▼ value of property length:\n" +
-                "    ✗ is equal to 1 : found 5"
+              """▼ Expect that "fnord":
+                |  ▼ value of property length:
+                |    ✗ is equal to 1 : found 5"""
+                .trimMargin()
             )
         }
         .and {
@@ -109,9 +114,10 @@ class Exceptions {
             .isA<AssertionFailedError>()
             .message
             .isEqualTo(
-              "▼ Expect that \"fnord\":\n" +
-                "  ▼ value of property length:\n" +
-                "    ✗ is less than 2"
+              """▼ Expect that "fnord":
+                |  ▼ value of property length:
+                |    ✗ is less than 2"""
+                .trimMargin()
             )
         }
         .and {
@@ -119,9 +125,10 @@ class Exceptions {
             .isA<AssertionFailedError>()
             .message
             .isEqualTo(
-              "▼ Expect that \"fnord\":\n" +
-                "  ▼ value of property length:\n" +
-                "    ✗ is not equal to 5"
+              """▼ Expect that "fnord":
+                |  ▼ value of property length:
+                |    ✗ is not equal to 5"""
+                .trimMargin()
             )
         }
     }
@@ -144,12 +151,13 @@ class Exceptions {
         .isA<CompoundAssertionFailure>()
         .and {
           message.isEqualTo(
-            "▼ Expect that \"fnord\":\n" +
-              "  ▼ value of property length:\n" +
-              "    ✓ is greater than 0\n" +
-              "    ✗ is equal to 1 : found 5\n" +
-              "    ✗ is less than 2\n" +
-              "    ✗ is not equal to 5"
+            """▼ Expect that "fnord":
+              |  ▼ value of property length:
+              |    ✓ is greater than 0
+              |    ✗ is equal to 1 : found 5
+              |    ✗ is less than 2
+              |    ✗ is not equal to 5"""
+              .trimMargin()
           )
         }
         .get { failures }
@@ -158,12 +166,13 @@ class Exceptions {
         .isA<AssertionFailedError>()
         .message
         .isEqualTo(
-          "▼ Expect that \"fnord\":\n" +
-            "  ▼ value of property length:\n" +
-            "    ✓ is greater than 0\n" +
-            "    ✗ is equal to 1 : found 5\n" +
-            "    ✗ is less than 2\n" +
-            "    ✗ is not equal to 5"
+          """▼ Expect that "fnord":
+            |  ▼ value of property length:
+            |    ✓ is greater than 0
+            |    ✗ is equal to 1 : found 5
+            |    ✗ is less than 2
+            |    ✗ is not equal to 5"""
+            .trimMargin()
         )
     }
   }
@@ -179,13 +188,14 @@ class Exceptions {
           .isA<AssertionFailedError>()
           .message
           .isEqualTo(
-            "▼ Expect that [\"catflap\", \"rubberplant\", \"marzipan\"]:\n" +
-              "  ✗ contains exactly the elements [\"catflap\", \"rubberplant\"]\n" +
-              "    ✓ contains \"catflap\"\n" +
-              "    ✓ …at index 0\n" +
-              "    ✓ contains \"rubberplant\"\n" +
-              "    ✓ …at index 1\n" +
-              "    ✗ contains no further elements : found [\"marzipan\"]"
+            """▼ Expect that ["catflap", "rubberplant", "marzipan"]:
+              |  ✗ contains exactly the elements ["catflap", "rubberplant"]
+              |    ✓ contains "catflap"
+              |    ✓ …at index 0
+              |    ✓ contains "rubberplant"
+              |    ✓ …at index 1
+              |    ✗ contains no further elements : found ["marzipan"]"""
+              .trimMargin()
           )
       }
   }
@@ -208,20 +218,22 @@ class Exceptions {
               .isA<AssertionFailedError>()
               .message
               .isEqualTo(
-                "▼ Expect that [\"catflap\", \"rubberplant\", \"marzipan\"]:\n" +
-                  "  ✗ has size 2 : found 3"
+                """▼ Expect that ["catflap", "rubberplant", "marzipan"]:
+                  |  ✗ has size 2 : found 3"""
+                  .trimMargin()
               )
             get(1)
               .isA<AssertionFailedError>()
               .message
               .isEqualTo(
-                "▼ Expect that [\"catflap\", \"rubberplant\", \"marzipan\"]:\n" +
-                  "  ✗ contains exactly the elements [\"catflap\", \"rubberplant\"]\n" +
-                  "    ✓ contains \"catflap\"\n" +
-                  "    ✓ …at index 0\n" +
-                  "    ✓ contains \"rubberplant\"\n" +
-                  "    ✓ …at index 1\n" +
-                  "    ✗ contains no further elements : found [\"marzipan\"]"
+                """▼ Expect that ["catflap", "rubberplant", "marzipan"]:
+                  |  ✗ contains exactly the elements ["catflap", "rubberplant"]
+                  |    ✓ contains "catflap"
+                  |    ✓ …at index 0
+                  |    ✓ contains "rubberplant"
+                  |    ✓ …at index 1
+                  |    ✗ contains no further elements : found ["marzipan"]"""
+                  .trimMargin()
               )
           }
       }

--- a/strikt-core/src/test/kotlin/strikt/Exceptions.kt
+++ b/strikt-core/src/test/kotlin/strikt/Exceptions.kt
@@ -29,13 +29,12 @@ class Exceptions {
     }.let { error ->
       expectThat(error)
         .isA<AssertionFailedError>()
-        .and {
-          message.isEqualTo(
+        .message
+        .isEqualTo(
             "▼ Expect that \"fnord\":\n" +
               "  ✓ has length 5\n" +
               "  ✗ is upper case"
           )
-        }
     }
   }
 

--- a/strikt-core/src/test/kotlin/strikt/Exceptions.kt
+++ b/strikt-core/src/test/kotlin/strikt/Exceptions.kt
@@ -35,7 +35,7 @@ class Exceptions {
             |  ✓ has length 5
             |  ✗ is upper case"""
             .trimMargin()
-          )
+        )
     }
   }
 

--- a/strikt-core/src/test/kotlin/strikt/docs/Assertions.kt
+++ b/strikt-core/src/test/kotlin/strikt/docs/Assertions.kt
@@ -77,7 +77,6 @@ internal class Assertions {
     val s = """ // IGNORE
     ▼ Expect that 1:
       ✗ is less than 1
-      ✗ is an instance of java.lang.Integer : found java.lang.Long
       ✗ is greater than 1
     """ // IGNORE
     // END assertion_styles_6

--- a/strikt-core/src/test/kotlin/strikt/docs/Assertions.kt
+++ b/strikt-core/src/test/kotlin/strikt/docs/Assertions.kt
@@ -100,10 +100,8 @@ internal class Assertions {
     ▼ Expect that "fnord":
       ✓ is an instance of java.lang.String
       ✗ has length 1 : found 5
-      ✗ is upper case
     ▼ Expect that 1:
       ✗ is less than 1
-      ✗ is an instance of java.lang.Integer : found java.lang.Long
       ✗ is greater than 1
     """ // IGNORE
     // END assertion_styles_8


### PR DESCRIPTION
- Ensures that chains inside of blocks still fail fast. Fixes #141 
- Ensures `get` is runtime type safe. It's now a no-op when preceded by a failing type-narrowing assertion. Fixes #132 


