### PR TITLE
Add assertion endsWith(Char)

### DIFF
--- a/strikt-core/src/main/kotlin/strikt/assertions/CharSequence.kt
+++ b/strikt-core/src/main/kotlin/strikt/assertions/CharSequence.kt
@@ -38,7 +38,7 @@ fun <T : CharSequence> Builder<T>.startsWith(expected: Char): Builder<T> =
     if (it.startsWith(expected)) {
       pass()
     } else {
-      fail(actual = it[0])
+      fail(actual = it.first())
     }
   }
 
@@ -51,6 +51,18 @@ fun <T : CharSequence> Builder<T>.startsWith(expected: CharSequence): Builder<T>
       pass()
     } else {
       fail(actual = it.take(expected.length))
+    }
+  }
+
+/**
+ * Asserts that the subject ends with the [expected] character.
+ */
+fun <T : CharSequence> Builder<T>.endsWith(expected: Char): Builder<T> =
+  assert("starts with %s", expected) {
+    if (it.endsWith(expected)) {
+      pass()
+    } else {
+      fail(actual = it.last())
     }
   }
 

--- a/strikt-core/src/main/kotlin/strikt/assertions/CharSequence.kt
+++ b/strikt-core/src/main/kotlin/strikt/assertions/CharSequence.kt
@@ -58,7 +58,7 @@ fun <T : CharSequence> Builder<T>.startsWith(expected: CharSequence): Builder<T>
  * Asserts that the subject ends with the [expected] character.
  */
 fun <T : CharSequence> Builder<T>.endsWith(expected: Char): Builder<T> =
-  assert("starts with %s", expected) {
+  assert("ends with %s", expected) {
     if (it.endsWith(expected)) {
       pass()
     } else {


### PR DESCRIPTION
Since we have the assertion `startsWith(expected: Char)`, why not have `endsWith(expected: Char)` too? 😄 

Btw, this is the best assertion lib for Kotlin!