### PR TITLE
Suppress Strikt portion of assertion error

### DIFF
--- a/strikt-core/src/main/kotlin/strikt/internal/AssertionStrategy.kt
+++ b/strikt-core/src/main/kotlin/strikt/internal/AssertionStrategy.kt
@@ -191,7 +191,7 @@ internal sealed class AssertionStrategy {
     message: String,
     failed: Failed?
   ): AssertionFailedError {
-    return if (failed?.comparison != null)
+    val error = if (failed?.comparison != null)
       AssertionFailedError(
         message,
         failed.comparison.expected,
@@ -203,5 +203,16 @@ internal sealed class AssertionStrategy {
         message,
         failed?.cause
       )
+
+    val stackTrace = error.stackTrace
+    val lastIndex = stackTrace
+      .indexOfLast { it.className.startsWith("strikt") }
+    val suppressedElements = stackTrace.copyOfRange(0, lastIndex)
+    val remainingElements = stackTrace.copyOfRange(lastIndex + 1, stackTrace.lastIndex)
+    error.stackTrace = remainingElements
+    val striktError = AssertionFailedError()
+    striktError.stackTrace = suppressedElements
+    error.addSuppressed(striktError)
+    return error
   }
 }

--- a/strikt-core/src/test/kotlin/strikt/assertions/Assertions.kt
+++ b/strikt-core/src/test/kotlin/strikt/assertions/Assertions.kt
@@ -1,0 +1,30 @@
+package strikt.assertions
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.TestFactory
+import org.junit.jupiter.api.assertThrows
+import org.opentest4j.AssertionFailedError
+import strikt.api.catching
+import strikt.api.expectThat
+import strikt.api.expectThrows
+
+@DisplayName("assertions")
+internal object Assertions {
+
+  @TestFactory
+  fun suppression() = assertionTests<Any?> {
+    context("failing") {
+      fixture { expectThat(false) }
+
+      test("exceptions are suppressed") {
+        val error = catching {
+          isEqualTo(true)
+        }
+        expectThat(error!!.stackTrace.none { it.className.startsWith("strikt") })
+        val suppressed = error.suppressed
+        expectThat(suppressed.size).isEqualTo(1)
+        expectThat(suppressed.single().stackTrace.all { it.methodName.startsWith("strict") })
+      }
+    }
+  }
+}


### PR DESCRIPTION
How's this look?

```org.opentest4j.AssertionFailedError: ▼ Expect that false:
  ✗ is equal to true : found false
	at dev.minutest.TestContextBuilder$test$1.invoke(ContextBuilder.kt:59)
	at dev.minutest.TestContextBuilder$test$1.invoke(ContextBuilder.kt:15)
	at dev.minutest.Test.invoke(Node.kt)
	at dev.minutest.Test.invoke(Node.kt:39)
	at dev.minutest.internal.PreparedContext$runTest$1.invoke(PreparedContext.kt:22)
	at dev.minutest.internal.PreparedContextKt.tryMap(PreparedContext.kt:60)
	at dev.minutest.internal.PreparedContextKt.access$tryMap(PreparedContext.kt:1)
	at dev.minutest.internal.PreparedContext.runTest(PreparedContext.kt:22)
	at dev.minutest.internal.TestExecutor$andThen$1$runTest$testletForParent$1.invoke(TestExecutor.kt:25)
	at dev.minutest.internal.TestExecutor$andThen$1$runTest$testletForParent$1.invoke(TestExecutor.kt:17)
	at dev.minutest.internal.PreparedContext$runTest$1.invoke(PreparedContext.kt:22)
	at dev.minutest.internal.PreparedContextKt.tryMap(PreparedContext.kt:60)
	at dev.minutest.internal.PreparedContextKt.access$tryMap(PreparedContext.kt:1)
	at dev.minutest.internal.PreparedContext.runTest(PreparedContext.kt:22)
	at dev.minutest.internal.TestExecutor$andThen$1$runTest$testletForParent$1.invoke(TestExecutor.kt:25)
	at dev.minutest.internal.TestExecutor$andThen$1$runTest$testletForParent$1.invoke(TestExecutor.kt:17)
	at dev.minutest.internal.RootExecutor.runTest(TestExecutor.kt:36)
	at dev.minutest.internal.TestExecutor$andThen$1.runTest(TestExecutor.kt:28)
	at dev.minutest.internal.TestExecutor$andThen$1.runTest(TestExecutor.kt:28)
	at dev.minutest.internal.TestExecutor$DefaultImpls.runTest(TestExecutor.kt:12)
	at dev.minutest.internal.TestExecutor$andThen$1.runTest(TestExecutor.kt:17)
	at dev.minutest.junit.JUnit5MinutestsKt$toDynamicNode$1.execute(JUnit5Minutests.kt:59)
	at org.junit.jupiter.engine.descriptor.JupiterTestDescriptor.executeAndMaskThrowable(JupiterTestDescriptor.java:204)
	at org.junit.jupiter.engine.descriptor.DynamicTestTestDescriptor.execute(DynamicTestTestDescriptor.java:43)
	at org.junit.jupiter.engine.descriptor.DynamicTestTestDescriptor.execute(DynamicTestTestDescriptor.java:25)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:135)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
	at org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService$ExclusiveTask.compute(ForkJoinPoolHierarchicalTestExecutorService.java:171)
	at org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService.submit(ForkJoinPoolHierarchicalTestExecutorService.java:104)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask$DefaultDynamicTestExecutor.execute(NodeTestTask.java:198)
	at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:184)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
	at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
	at java.util.stream.ReferencePipeline$11$1.accept(ReferencePipeline.java:373)
	at java.util.Iterator.forEachRemaining(Iterator.java:116)
	at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.forEachOrdered(ReferencePipeline.java:423)
	at org.junit.jupiter.engine.descriptor.DynamicContainerTestDescriptor.execute(DynamicContainerTestDescriptor.java:65)
	at org.junit.jupiter.engine.descriptor.DynamicContainerTestDescriptor.execute(DynamicContainerTestDescriptor.java:33)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:135)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
	at org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService$ExclusiveTask.compute(ForkJoinPoolHierarchicalTestExecutorService.java:171)
	at org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService.submit(ForkJoinPoolHierarchicalTestExecutorService.java:104)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask$DefaultDynamicTestExecutor.execute(NodeTestTask.java:198)
	at java.util.Optional.ifPresent(Optional.java:159)
	at org.junit.jupiter.engine.descriptor.TestFactoryTestDescriptor.lambda$invokeTestMethod$1(TestFactoryTestDescriptor.java:101)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.jupiter.engine.descriptor.TestFactoryTestDescriptor.invokeTestMethod(TestFactoryTestDescriptor.java:88)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:127)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:68)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:135)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
	at org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService$ExclusiveTask.compute(ForkJoinPoolHierarchicalTestExecutorService.java:171)
	at org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService.invokeAll(ForkJoinPoolHierarchicalTestExecutorService.java:115)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
	at org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService$ExclusiveTask.compute(ForkJoinPoolHierarchicalTestExecutorService.java:171)
	at org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService.invokeAll(ForkJoinPoolHierarchicalTestExecutorService.java:115)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
	at org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService$ExclusiveTask.compute(ForkJoinPoolHierarchicalTestExecutorService.java:171)
	at java.util.concurrent.RecursiveAction.exec(RecursiveAction.java:189)
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
	Suppressed: org.opentest4j.AssertionFailedError
		at strikt.internal.AssertionStrategy.createAssertionFailedError$io_strikt_strikt_core_main(AssertionStrategy.kt:195)
		at strikt.internal.AssertionStrategy$Throwing.afterStatusSet(AssertionStrategy.kt:151)
		at strikt.internal.AssertionStrategy$appendAtomic$1.fail(AssertionStrategy.kt:44)
		at strikt.api.AtomicAssertion$DefaultImpls.fail$default(AtomicAssertion.kt:19)
		at strikt.assertions.AnyKt$isEqualTo$1.invoke(Any.kt:66)
		at strikt.assertions.AnyKt$isEqualTo$1.invoke(Any.kt)
		at strikt.internal.AssertionBuilder.assert(AssertionBuilder.kt:55)
		at strikt.internal.AssertionBuilder.assert(AssertionBuilder.kt:12)
		at strikt.assertions.AnyKt.isEqualTo(Any.kt:54)
		at strikt.assertions.Assertions$suppression$1$1$2$error$1.invokeSuspend(Assertions.kt:21)
		at strikt.assertions.Assertions$suppression$1$1$2$error$1.invoke(Assertions.kt)
		at strikt.api.CatchingKt$catching$1.invokeSuspend(Catching.kt:16)
		at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:32)
		at kotlinx.coroutines.DispatchedTask.run(Dispatched.kt:233)
		at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.kt:116)
		at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:76)
		at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:53)
		at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
		at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:35)
		at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source)
		at strikt.api.CatchingKt.catching(Catching.kt:15)
		at strikt.assertions.Assertions$suppression$1$1$2.invoke(Assertions.kt:20)```