### PR TITLE
Introduce IO assertions on `java.io.File` and `java.nio.file.Path`

### DIFF
--- a/strikt-core/src/main/kotlin/strikt/assertions/File.kt
+++ b/strikt-core/src/main/kotlin/strikt/assertions/File.kt
@@ -1,0 +1,67 @@
+package strikt.assertions
+
+import strikt.api.Assertion.Builder
+import java.io.File
+import java.net.URI
+import java.nio.charset.Charset
+import java.nio.file.Path
+
+// java.io.File
+/**
+ * Maps this assertion to an assertion on the name of the file of the subject.
+ *
+ * @see File.getName
+ */
+val <T : File> Builder<T>.name: Builder<String>
+  get() = get("name", File::getName)
+
+/**
+ * Maps this assertion to an assertion on the parent file or `null` if the subject does not have a parent.
+ *
+ * @see File.getParent
+ */
+val <T : File> Builder<T>.parent: Builder<String?>
+  get() = get("parent", File::getParent)
+
+/**
+ * Maps this assertion to an assertion on a path object representing this subject.
+ *
+ * @see File.toPath
+ */
+fun <T : File> Builder<T>.toPath(): Builder<Path> =
+  get("as Path", File::toPath)
+
+// https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.io/java.io.-file/index.html
+/**
+ * Maps this assertion to an assertion on the file extension (not including the dot) or empty string if it not have one.
+ *
+ * @see File.extension
+ */
+val <T : File> Builder<T>.extension: Builder<String>
+  get() = get("extension", File::extension)
+
+/**
+ * Maps this assertion to an assertion on the file name without the extension.
+ *
+ * @see File.nameWithoutExtension
+ */
+val <T : File> Builder<T>.nameWithoutExtension: Builder<String>
+  get() = get("name without extension", File::nameWithoutExtension)
+
+/**
+ * Maps this assertion to an assertion on the lines of the subject decoded using the provided [charset].
+ *
+ * @param charset the charset used to decode the content
+ * @see readLines
+ */
+fun <T : File> Builder<T>.lines(charset: Charset = Charsets.UTF_8): Builder<List<String>> =
+  get("lines (decoded with charset $charset)") { readLines(charset) }
+
+/**
+ * Maps this assertion to an assertion on the complete text of the subject decoded using the provided [charset].
+ *
+ * @param charset the charset used to decode the content
+ * @see readText
+ */
+fun <T : File> Builder<T>.text(charset: Charset = Charsets.UTF_8): Builder<String> =
+  get("text (decoded with charset $charset)") { readText(charset) }

--- a/strikt-core/src/main/kotlin/strikt/assertions/Path.kt
+++ b/strikt-core/src/main/kotlin/strikt/assertions/Path.kt
@@ -1,0 +1,195 @@
+package strikt.assertions
+
+import strikt.api.Assertion.Builder
+import java.io.File
+import java.nio.charset.Charset
+import java.nio.file.Files
+import java.nio.file.LinkOption
+import java.nio.file.Path
+
+// java.nio.file.Path
+/**
+ * Asserts that the subject end with the provided path.
+ *
+ * @param other the given path
+ * @see Path.endsWith
+ */
+fun <T : Path> Builder<T>.endsWith(other: Path): Builder<T> =
+  assert("ends with %s", other) {
+    if (it.endsWith(other)) {
+      pass()
+    } else {
+      fail(actual = it)
+    }
+  }
+
+/**
+ * Asserts that the subject end with the provided path string.
+ *
+ * @param other the given path string
+ * @see Path.endsWith
+ */
+fun <T : Path> Builder<T>.endsWith(other: String): Builder<T> =
+  assert("ends with %s", other) {
+    if (it.endsWith(other)) {
+      pass()
+    } else {
+      fail(actual = it)
+    }
+  }
+
+/**
+ * Maps this assertion to an assertion on the path representing the name of the subject.
+ *
+ * @see Path.getFileName
+ */
+val <T : Path> Builder<T>.fileName: Builder<Path>
+  get() = get("file name", Path::getFileName)
+
+/**
+ * Asserts that the subject is an absolute path.
+ *
+ * @see Path.isAbsolute
+ */
+fun <T : Path> Builder<T>.isAbsolute(): Builder<T>
+  = assertThat("is absolute", Path::isAbsolute)
+
+/**
+ * Maps this assertion to an assertion on the parent path or `null` if the subject does not have a parent.
+ *
+ * @see Path.getParent
+ */
+val <T : Path> Builder<T>.parent: Builder<Path?>
+  get() = get("parent", Path::getParent)
+
+/**
+ * Maps this assertion to an assertion of this subject resolved with the provided path.
+ *
+ * @param other the path to resolve against this subject's path
+ * @see Path.resolve
+ */
+fun <T : Path> Builder<T>.resolve(other: Path): Builder<Path> =
+  get("resolved against $other") { resolve(other) }
+
+/**
+ * Maps this assertion to an assertion of this subject resolved with the provided path.
+ *
+ * @param other the path string to resolve against this subject's path
+ * @see Path.resolve
+ */
+fun <T : Path> Builder<T>.resolve(other: String): Builder<Path> =
+  get("resolved against $other") { resolve(other) }
+
+/**
+ * Asserts that the subject starts with the provided path.
+ *
+ * @param other the given path
+ * @see Path.startsWith
+ */
+fun <T : Path> Builder<T>.startsWith(other: Path): Builder<T> =
+  assertThat("starts with %s", expected = other) { it.startsWith(other) }
+
+/**
+ * Asserts that the subject starts with the provided path.
+ *
+ * @param other the given path string
+ * @see Path.startsWith
+ */
+fun <T : Path> Builder<T>.startsWith(other: String): Builder<T> =
+  assertThat("starts with %s", expected = other) { it.startsWith(other) }
+
+/**
+ * Maps this assertion to an assertion on the file object representing this subject.
+ *
+ * @see Path.toFile
+ */
+fun <T : Path> Builder<T>.toFile(): Builder<File> =
+  get("as File", Path::toFile)
+
+// java.nio.file.Files
+/**
+ * Asserts that the subject exists, handling symbolic links according to the provided [options]
+ *
+ * @param options the options indicating how symbolic links are handled
+ * @see Files.exists
+ */
+fun <T : Path> Builder<T>.exists(vararg options: LinkOption = emptyArray()): Builder<T> =
+  assertThat(descriptionForOptions("exists", options)) { Files.exists(it, *options) }
+
+/**
+ * Asserts that the subject is a directory, handling symbolic links according to the provided [options].
+ *
+ * @param options the options indicating how symbolic links are handled
+ * @see Files.isDirectory
+ */
+fun <T : Path> Builder<T>.isDirectory(vararg options: LinkOption = emptyArray()): Builder<T> =
+  assertThat(descriptionForOptions("is directory", options)) { Files.isDirectory(it, *options) }
+
+/**
+ * Asserts that the subject is executable link.
+ *
+ * @see Files.isExecutable
+ */
+fun <T : Path> Builder<T>.isExecutable(): Builder<T> =
+  assertThat("is executable") { Files.isExecutable(it) }
+
+/**
+ * Asserts that the subject is readable.
+ *
+ * @see Files.isReadable
+ */
+fun <T : Path> Builder<T>.isReadable(): Builder<T> =
+  assertThat("is readable") { Files.isReadable(it) }
+
+/**
+ * Asserts that the subject is a regular file, handling symbolic links according to the provided [options].
+ *
+ * @param options the options indicating how symbolic links are handled
+ * @see Files.isRegularFile
+ */
+fun <T : Path> Builder<T>.isRegularFile(vararg options: LinkOption = emptyArray()): Builder<T> =
+  assertThat(descriptionForOptions("is regular file", options)) { Files.isRegularFile(it, *options) }
+
+/**
+ * Asserts that the subject is a symbolic link.
+ *
+ * @see Files.isSymbolicLink
+ */
+fun <T : Path> Builder<T>.isSymbolicLink(): Builder<T>
+  = assertThat("is symbolic lnk") { Files.isSymbolicLink(it) }
+
+/**
+ * Maps this assertion to an assertion over all lines of this subject path decoded using the `UTF-8` charset.
+ *
+ * @see Files.readAllLines
+ */
+fun <T : Path> Builder<T>.allLines(): Builder<List<String>>
+  = get("all lines (UTF-8 encoding)", Files::readAllLines)
+
+/**
+ * Maps this assertion to an assertion over all lines of this subject path decoded using the provided [charset].
+ *
+ * @param charset the charset to use in decoding
+ * @see Files.readAllLines
+ */
+fun <T : Path> Builder<T>.allLines(charset: Charset): Builder<List<String>> =
+  get("all lines ($charset encoding)") { Files.readAllLines(this, charset) }
+
+/**
+ * Maps this assertion to an assertion over the byte size of the subject path.
+ *
+ * @see Files.size
+ */
+val <T : Path> Builder<T>.size: Builder<Long>
+  get() = get("size (in bytes)", Files::size)
+
+/**
+ * Converts a description to another description
+ * Useful is methods that take an optional array of [LinkOption]
+ */
+private fun descriptionForOptions(description: String, options: Array<out LinkOption>): String =
+  if (options.isNotEmpty()) {
+    "$description with options ${options.contentToString()}"
+  } else {
+    description
+  }

--- a/strikt-core/src/test/kotlin/strikt/assertions/FileAssertions.kt
+++ b/strikt-core/src/test/kotlin/strikt/assertions/FileAssertions.kt
@@ -1,5 +1,6 @@
 package strikt.assertions
 
+import dev.minutest.TestDescriptor
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.TestFactory
 import org.junit.jupiter.api.io.TempDir
@@ -8,9 +9,11 @@ import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
 
-// TODO: improve how fixture Path's are generated since we are leverage @TempDir, which only gets created once for the entire minutest test context
+// TODO: improve how fixture Path's are generated since we leveraging @TempDir, which only gets created once for the entire minutest test context
 @DisplayName("assertions on java.io.File")
 internal object FileAssertions {
+
+  private fun TestDescriptor.joinFullName() = fullName().joinToString(separator = "_")
 
   @TestFactory
   internal fun name() = assertionTests<File> {
@@ -102,7 +105,7 @@ internal object FileAssertions {
     context("subject is an empty file") {
       fixture {
         expectThat(
-          Files.createFile(directory.resolve(it.fullName().joinToString(separator = "_"))).toFile()
+          Files.createFile(directory.resolve(it.joinFullName())).toFile()
         )
       }
       test("then lines() maps to an empty list") {
@@ -118,7 +121,7 @@ internal object FileAssertions {
     context("subject is a single line file") {
       fixture {
         expectThat(
-          Files.write(directory.resolve(it.fullName().joinToString(separator = "_")), listOf("first line")).toFile()
+          Files.write(directory.resolve(it.joinFullName()), listOf("first line")).toFile()
         )
       }
 
@@ -138,7 +141,7 @@ internal object FileAssertions {
     context("subject is an empty file") {
       fixture {
         expectThat(
-          Files.createFile(directory.resolve(it.fullName().joinToString(separator = "_"))).toFile()
+          Files.createFile(directory.resolve(it.joinFullName())).toFile()
         )
       }
       test("then text() maps to an empty list") {
@@ -154,7 +157,7 @@ internal object FileAssertions {
     context("subject is a single line file") {
       fixture {
         expectThat(
-          Files.write(directory.resolve(it.fullName().joinToString(separator = "_")), "first line".toByteArray()).toFile()
+          Files.write(directory.resolve(it.joinFullName()), "first line".toByteArray()).toFile()
         )
       }
 

--- a/strikt-core/src/test/kotlin/strikt/assertions/FileAssertions.kt
+++ b/strikt-core/src/test/kotlin/strikt/assertions/FileAssertions.kt
@@ -1,0 +1,171 @@
+package strikt.assertions
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.TestFactory
+import org.junit.jupiter.api.io.TempDir
+import strikt.api.expectThat
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+
+// TODO: improve how fixture Path's are generated since we are leverage @TempDir, which only gets created once for the entire minutest test context
+@DisplayName("assertions on java.io.File")
+internal object FileAssertions {
+
+  @TestFactory
+  internal fun name() = assertionTests<File> {
+    context("subject parent exists") {
+      fixture { expectThat(File("example.txt")) }
+      test("then name maps to the file name") {
+        name
+          .isEqualTo("example.txt")
+      }
+    }
+
+    context("subject file is root") {
+      fixture { expectThat(File("/")) }
+      test("then name maps to an empty string") {
+        name
+          .isEmpty()
+      }
+    }
+  }
+
+  @TestFactory
+  internal fun parent() = assertionTests<File> {
+    context("subject parent exists") {
+      fixture { expectThat(File("parent", "child")) }
+      test("then parent maps to the parent file") {
+        parent
+          .isEqualTo("parent")
+      }
+    }
+
+    context("subject file is root") {
+      fixture { expectThat(File("/")) }
+      test("then parent maps to a null value") {
+        parent
+          .isNull()
+      }
+    }
+  }
+
+  @TestFactory
+  internal fun toPath() = assertionTests<File> {
+    fixture { expectThat(File("parent", "child")) }
+    test("mapped value is a Path") {
+      toPath()
+        .isA<Path>()
+    }
+  }
+
+  @TestFactory
+  internal fun extension() = assertionTests<File> {
+    context("given the subject is a file with an extension") {
+      fixture { expectThat(File("example.txt")) }
+      test("then the mapped value is the extension") {
+        extension
+          .isEqualTo("txt")
+      }
+    }
+
+    context("given the subject is a file without an extension") {
+      fixture { expectThat(File("example")) }
+      test("then the mapped value is an empty string") {
+        extension
+          .isEmpty()
+      }
+    }
+  }
+
+  @TestFactory
+  internal fun nameWithoutExtension() = assertionTests<File> {
+    context("given the subject is a file with an extension") {
+      fixture { expectThat(File("example.txt")) }
+      test("then the mapped value is the extension") {
+        nameWithoutExtension
+          .isEqualTo("example")
+      }
+    }
+
+    context("given the subject is a file without an extension") {
+      fixture { expectThat(File("example")) }
+      test("then the mapped value is the filename") {
+        nameWithoutExtension
+          .isEqualTo("example")
+      }
+    }
+  }
+
+  @TestFactory
+  internal fun lines(@TempDir directory: Path) = assertionTests<File> {
+    context("subject is an empty file") {
+      fixture {
+        expectThat(
+          Files.createFile(directory.resolve(it.fullName().joinToString(separator = "_"))).toFile()
+        )
+      }
+      test("then lines() maps to an empty list") {
+        lines()
+          .isEmpty()
+      }
+      test("then lines(${Charsets.UTF_8}) maps to an empty list") {
+        lines(Charsets.UTF_8)
+          .isEmpty()
+      }
+    }
+
+    context("subject is a single line file") {
+      fixture {
+        expectThat(
+          Files.write(directory.resolve(it.fullName().joinToString(separator = "_")), listOf("first line")).toFile()
+        )
+      }
+
+      test("then lines() maps to a singleton list of the line") {
+        lines()
+          .containsExactly("first line")
+      }
+      test("then lines(${Charsets.UTF_8}) maps to a singleton list of the line") {
+        lines(Charsets.UTF_8)
+          .containsExactly("first line")
+      }
+    }
+  }
+
+  @TestFactory
+  internal fun text(@TempDir directory: Path) = assertionTests<File> {
+    context("subject is an empty file") {
+      fixture {
+        expectThat(
+          Files.createFile(directory.resolve(it.fullName().joinToString(separator = "_"))).toFile()
+        )
+      }
+      test("then text() maps to an empty list") {
+        text()
+          .isEmpty()
+      }
+      test("then text(${Charsets.UTF_8}) maps to an empty list") {
+        text(Charsets.UTF_8)
+          .isEmpty()
+      }
+    }
+
+    context("subject is a single line file") {
+      fixture {
+        expectThat(
+          Files.write(directory.resolve(it.fullName().joinToString(separator = "_")), "first line".toByteArray()).toFile()
+        )
+      }
+
+      test("then text() maps to the file content") {
+        text()
+          .isEqualTo("first line")
+      }
+      test("then lines(${Charsets.UTF_8}) maps to the file content") {
+        text(Charsets.UTF_8)
+          .isEqualTo("first line")
+      }
+    }
+  }
+}

--- a/strikt-core/src/test/kotlin/strikt/assertions/PathAssertions.kt
+++ b/strikt-core/src/test/kotlin/strikt/assertions/PathAssertions.kt
@@ -1,0 +1,468 @@
+package strikt.assertions
+
+import org.junit.jupiter.api.TestFactory
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+import strikt.api.expectThat
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.LinkOption
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.attribute.PosixFilePermission
+import java.nio.file.attribute.PosixFilePermissions
+
+// TODO: improve how fixture Path's are generated since we are leverage @TempDir, which only gets created once for the entire minutest test context
+internal object PathAssertions {
+
+  @TestFactory
+  internal fun endsWith() = assertionTests<Path> {
+    fixture { expectThat(Paths.get("startsWith", "endsWith")) }
+
+    context("passes when the subject ends with") {
+      test("the String type path") {
+        endsWith("endsWith")
+      }
+
+      test("the Path type path") {
+        endsWith(Paths.get("endsWith"))
+      }
+    }
+
+    context("fails when the subject does not end with") {
+      test("the String type path") {
+        assertThrows<AssertionError> {
+          endsWith("doesNotEndsWith")
+        }
+      }
+
+      test("the Path type path") {
+        assertThrows<AssertionError> {
+          endsWith(Paths.get("doesNotEndsWith"))
+        }
+      }
+    }
+  }
+
+  @TestFactory
+  internal fun fileName() = assertionTests<Path> {
+    fixture { expectThat(Paths.get("some", "path", "with", "name")) }
+
+    test("maps to a Path of the file name") {
+      fileName
+        .isEqualTo(Paths.get("name"))
+    }
+  }
+
+  @TestFactory
+  internal fun isAbsolute() = assertionTests<Path> {
+    context("when subject is an absolute path") {
+      fixture { expectThat(Paths.get("/tmp", "path").toAbsolutePath()) }
+
+      test("then assertion passes") {
+        isAbsolute()
+      }
+    }
+
+    context("when subject is not an absolute path") {
+      fixture { expectThat(Paths.get("relative", "path")) }
+
+      test("then assertion fails") {
+        assertThrows<AssertionError> {
+          isAbsolute()
+        }
+      }
+    }
+  }
+
+  @TestFactory
+  internal fun parent() = assertionTests<Path> {
+    context("when subject is the root Path") {
+      fixture { expectThat(Paths.get("/").root) }
+      test("then the mapped value is null") {
+        parent.isNull()
+      }
+    }
+
+    context("when subject has a parent") {
+      fixture { expectThat(Paths.get("parent", "child")) }
+      test("then the mapped value is that parent") {
+        parent
+          .isNotNull()
+          .isEqualTo(Paths.get("parent"))
+      }
+    }
+  }
+
+  @TestFactory
+  internal fun resolve() = assertionTests<Path> {
+    fixture { expectThat(Paths.get("parent")) }
+
+    context("when the resolve value type is a Path") {
+      test("then the mapped assertion is the resolved path") {
+        resolve(Paths.get("child"))
+          .isEqualTo(Paths.get("parent", "child"))
+      }
+    }
+
+    context("when the resolve value type is a String") {
+      test("then the mapped assertion is the resolved path") {
+        resolve("child")
+          .isEqualTo(Paths.get("parent", "child"))
+      }
+    }
+  }
+
+  @TestFactory
+  internal fun startsWith() = assertionTests<Path> {
+    fixture { expectThat(Paths.get("startsWith", "endsWith")) }
+
+    context("passes when the subject starts with") {
+      test("the String type path") {
+        startsWith("startsWith")
+      }
+
+      test("the Path type path") {
+        startsWith(Paths.get("startsWith"))
+      }
+    }
+
+    context("fails when the subject does not start with") {
+      test("the String type path") {
+        assertThrows<AssertionError> {
+          startsWith("doesNotStartWith")
+        }
+      }
+
+      test("the Path type path") {
+        assertThrows<AssertionError> {
+          startsWith(Paths.get("doesNotStartWith"))
+        }
+      }
+    }
+  }
+
+  @TestFactory
+  internal fun toFile() = assertionTests<Path> {
+    fixture { expectThat(Paths.get("path", "of", "file")) }
+    test("mapped value is a File") {
+      toFile()
+        .isA<File>()
+    }
+  }
+
+  @TestFactory
+  internal fun exists(@TempDir directory: Path) = assertionTests<Path> {
+    context("assertion passes") {
+      context("when Path points to an existing file") {
+        fixture { expectThat(Files.createFile(directory.resolve(it.name))) }
+      }
+
+      context("when Path points to a symlink that resolves to an existing file") {
+        fixture {
+          expectThat(
+            Files.createSymbolicLink(
+              directory.resolve("${it.fullName().joinToString(separator = "_")}_symlink"),
+              Files.createFile(directory.resolve("${it.fullName().joinToString(separator = "_")}_target"))
+            )
+          )
+        }
+
+        test("and no link options are provided") {
+          exists()
+        }
+
+        test("and the ${LinkOption.NOFOLLOW_LINKS} is provided") {
+          exists(LinkOption.NOFOLLOW_LINKS)
+        }
+      }
+
+      context("when Path points to a symlink that resolves to a nonexistent file") {
+        fixture {
+          val symlink = Files.createSymbolicLink(
+            directory.resolve("${it.fullName().joinToString(separator = "_")}_symlink"),
+            directory.resolve("${it.fullName().joinToString(separator = "_")}_nonexistent-target")
+          )
+          expectThat(symlink)
+        }
+
+        test("and the ${LinkOption.NOFOLLOW_LINKS} is provided") {
+          exists(LinkOption.NOFOLLOW_LINKS)
+        }
+      }
+    }
+
+    context("assertion fails") {
+      context("when Path points to a nonexistent file") {
+        fixture { expectThat(directory.resolve(it.fullName().joinToString(separator = "_"))) }
+      }
+      context("when Path points to a symlink that resolves to an existing file") {
+        fixture {
+          val symlink = Files.createSymbolicLink(
+            directory.resolve("${it.fullName().joinToString(separator = "_")}_symlink"),
+            Files.createFile(directory.resolve("${it.fullName().joinToString(separator = "_")}_target"))
+          )
+          expectThat(symlink)
+        }
+
+        test("and no link options are provided") {
+          exists()
+        }
+
+        test("and the ${LinkOption.NOFOLLOW_LINKS} is provided") {
+          exists(LinkOption.NOFOLLOW_LINKS)
+        }
+      }
+
+      context("when Path points to a symlink that resolves to a nonexistent file") {
+        fixture {
+          val symlink = Files.createSymbolicLink(
+            directory.resolve("${it.fullName().joinToString(separator = "_")}_symlink"),
+            directory.resolve("${it.fullName().joinToString(separator = "_")}_nonexistent-target")
+          )
+          expectThat(symlink)
+        }
+
+        test("and no link options are provided") {
+          assertThrows<AssertionError> {
+            exists()
+          }
+        }
+      }
+    }
+  }
+
+  @TestFactory
+  internal fun isDirectory(@TempDir directory: Path) = assertionTests<Path> {
+    context("when subject Path is a regular file") {
+      fixture { expectThat(Files.createFile(directory.resolve(it.fullName().joinToString(separator = "_")))) }
+      test("assertion fails") {
+        assertThrows<AssertionError> {
+          isDirectory()
+        }
+      }
+    }
+
+    context("when subject Path is a directory") {
+      fixture { expectThat(Files.createDirectory(directory.resolve(it.fullName().joinToString(separator = "_")))) }
+      test("assertion passes") {
+        isDirectory()
+      }
+    }
+
+    context("when subject Path is a symlink") {
+      context("to a file") {
+        fixture {
+          expectThat(
+            Files.createSymbolicLink(
+              directory.resolve("${it.fullName().joinToString(separator = "_")}_link"),
+              Files.createFile(directory.resolve("${it.fullName().joinToString(separator = "_")}_target"))
+            )
+          )
+        }
+        test("assertion fails") {
+          assertThrows<AssertionError> {
+            isDirectory()
+          }
+        }
+      }
+
+      context("to a directory") {
+        fixture {
+          expectThat(
+            Files.createSymbolicLink(
+              directory.resolve("${it.fullName().joinToString(separator = "_")}_link"),
+              Files.createDirectory(directory.resolve(it.fullName().joinToString(separator = "_")))
+            )
+          )
+        }
+        test("succeeds when no link options are provided") {
+          isDirectory()
+        }
+        test("fails when ${LinkOption.NOFOLLOW_LINKS} options is provided") {
+          assertThrows<AssertionError> {
+            isDirectory(LinkOption.NOFOLLOW_LINKS)
+          }
+        }
+      }
+    }
+  }
+
+  @TestFactory
+  internal fun isExecutable(@TempDir directory: Path) = assertionTests<Path> {
+    context("passes when") {
+      fixture {
+        expectThat(
+          Files.createFile(
+            directory.resolve(it.fullName().joinToString(separator = "_")),
+            PosixFilePermissions.asFileAttribute(setOf(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_EXECUTE))
+          )
+        )
+      }
+      test("path has executable permission") {
+        isExecutable()
+      }
+    }
+
+    context("fails when") {
+      fixture {
+        expectThat(
+          Files.createFile(
+            directory.resolve(it.fullName().joinToString(separator = "_")),
+            PosixFilePermissions.asFileAttribute(setOf(PosixFilePermission.OWNER_READ))
+          )
+        )
+      }
+      test("path does not have executable permission") {
+        assertThrows<AssertionError> {
+          isExecutable()
+        }
+      }
+    }
+  }
+
+  @TestFactory
+  internal fun isReadable(@TempDir directory: Path) = assertionTests<Path> {
+    fixture { expectThat(directory) }
+    context("when subject is an existing directory") {
+      test("then assertion passes") {
+        isReadable()
+      }
+    }
+  }
+
+  @TestFactory
+  internal fun isRegularFile(@TempDir directory: Path) = assertionTests<Path> {
+    context("when subject is a regular file") {
+      fixture { expectThat(Files.createFile(directory.resolve(it.fullName().joinToString(separator = "_")))) }
+      test("then assertion passes when no link options are provided") {
+        isRegularFile()
+      }
+
+      test("then assertion passes when ${LinkOption.NOFOLLOW_LINKS} option is provide") {
+        isRegularFile(LinkOption.NOFOLLOW_LINKS)
+      }
+    }
+
+    context("subject is a directory") {
+      fixture { expectThat(Files.createDirectory(directory.resolve(it.fullName().joinToString(separator = "_")))) }
+      test("then assertion fails") {
+        assertThrows<AssertionError> {
+          isRegularFile()
+        }
+      }
+    }
+  }
+
+  @TestFactory
+  internal fun isSymbolicLink(@TempDir directory: Path) = assertionTests<Path> {
+    context("subject does not exist") {
+      fixture { expectThat(directory.resolve(it.fullName().joinToString(separator = "_"))) }
+      test("then assertion fails") {
+        assertThrows<AssertionError> {
+          isSymbolicLink()
+        }
+      }
+    }
+
+    context("subject is a regular file") {
+      fixture { expectThat(Files.createFile(directory.resolve(it.fullName().joinToString(separator = "_")))) }
+      test("then assertion fails") {
+        assertThrows<AssertionError> {
+          isSymbolicLink()
+        }
+      }
+    }
+
+    context("subject is a symlink that resolves to an existing file") {
+      context("that resolves to an existing file") {
+        fixture {
+          expectThat(
+            Files.createSymbolicLink(
+              directory.resolve("${it.fullName().joinToString(separator = "_")}_symlink"),
+              Files.createFile(directory.resolve("${it.fullName().joinToString(separator = "_")}_target"))
+            )
+          )
+        }
+
+        test("assertion passes") {
+          isSymbolicLink()
+        }
+      }
+      context("that resolves to a nonexistent file") {
+        fixture {
+          expectThat(
+            Files.createSymbolicLink(
+              directory.resolve("${it.fullName().joinToString(separator = "_")}_symlink"),
+              directory.resolve("${it.fullName().joinToString(separator = "_")}_target")
+            )
+          )
+        }
+
+        test("assertion passes") {
+          isSymbolicLink()
+        }
+      }
+    }
+  }
+
+  @TestFactory
+  internal fun allLines(@TempDir directory: Path) = assertionTests<Path> {
+    context("subject is an empty file") {
+      fixture {
+        expectThat(Files.createFile(directory.resolve(it.fullName().joinToString(separator = "_"))))
+      }
+      test("then allLines() maps to an empty list") {
+        allLines()
+          .isEmpty()
+      }
+      test("then allLines(${Charsets.UTF_8}) maps to an empty list") {
+        allLines(Charsets.UTF_8)
+          .isEmpty()
+      }
+    }
+
+    context("subject is a single line file") {
+      fixture {
+        expectThat(Files.write(directory.resolve(it.fullName().joinToString(separator = "_")), listOf("first line")))
+      }
+
+      test("then allLines() maps to a singleton list of the line") {
+        allLines()
+          .containsExactly("first line")
+      }
+      test("then allLines(${Charsets.UTF_8}) maps to a singleton list of the line") {
+        allLines(Charsets.UTF_8)
+          .containsExactly("first line")
+      }
+    }
+  }
+
+  @TestFactory
+  internal fun size(@TempDir directory: Path) = assertionTests<Path> {
+
+    context("subject is an empty file") {
+      fixture {
+        expectThat(
+          Files.createFile(directory.resolve(it.fullName().joinToString(separator = "_")))
+        )
+      }
+      test("then size maps to a 0 ") {
+        size
+          .isEqualTo(0)
+      }
+    }
+
+    context("subject is a 4-byte file") {
+      fixture {
+        expectThat(
+          Files.write(Files.createFile(directory.resolve(it.fullName().joinToString(separator = "_"))), byteArrayOf(1, 2, 3, 4))
+        )
+      }
+      test("then size maps to a 4") {
+        size
+          .isEqualTo(4)
+      }
+    }
+  }
+}

--- a/strikt-core/src/test/kotlin/strikt/assertions/PathAssertions.kt
+++ b/strikt-core/src/test/kotlin/strikt/assertions/PathAssertions.kt
@@ -1,5 +1,6 @@
 package strikt.assertions
 
+import dev.minutest.TestDescriptor
 import org.junit.jupiter.api.TestFactory
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.io.TempDir
@@ -12,8 +13,10 @@ import java.nio.file.Paths
 import java.nio.file.attribute.PosixFilePermission
 import java.nio.file.attribute.PosixFilePermissions
 
-// TODO: improve how fixture Path's are generated since we are leverage @TempDir, which only gets created once for the entire minutest test context
+// TODO: improve how fixture Path's are generated since we leveraging @TempDir, which only gets created once for the entire minutest test context
 internal object PathAssertions {
+
+  private fun TestDescriptor.joinFullName() = fullName().joinToString(separator = "_")
 
   @TestFactory
   internal fun endsWith() = assertionTests<Path> {
@@ -162,8 +165,8 @@ internal object PathAssertions {
         fixture {
           expectThat(
             Files.createSymbolicLink(
-              directory.resolve("${it.fullName().joinToString(separator = "_")}_symlink"),
-              Files.createFile(directory.resolve("${it.fullName().joinToString(separator = "_")}_target"))
+              directory.resolve("${it.joinFullName()}_symlink"),
+              Files.createFile(directory.resolve("${it.joinFullName()}_target"))
             )
           )
         }
@@ -180,8 +183,8 @@ internal object PathAssertions {
       context("when Path points to a symlink that resolves to a nonexistent file") {
         fixture {
           val symlink = Files.createSymbolicLink(
-            directory.resolve("${it.fullName().joinToString(separator = "_")}_symlink"),
-            directory.resolve("${it.fullName().joinToString(separator = "_")}_nonexistent-target")
+            directory.resolve("${it.joinFullName()}_symlink"),
+            directory.resolve("${it.joinFullName()}_nonexistent-target")
           )
           expectThat(symlink)
         }
@@ -194,13 +197,13 @@ internal object PathAssertions {
 
     context("assertion fails") {
       context("when Path points to a nonexistent file") {
-        fixture { expectThat(directory.resolve(it.fullName().joinToString(separator = "_"))) }
+        fixture { expectThat(directory.resolve(it.joinFullName())) }
       }
       context("when Path points to a symlink that resolves to an existing file") {
         fixture {
           val symlink = Files.createSymbolicLink(
-            directory.resolve("${it.fullName().joinToString(separator = "_")}_symlink"),
-            Files.createFile(directory.resolve("${it.fullName().joinToString(separator = "_")}_target"))
+            directory.resolve("${it.joinFullName()}_symlink"),
+            Files.createFile(directory.resolve("${it.joinFullName()}_target"))
           )
           expectThat(symlink)
         }
@@ -217,8 +220,8 @@ internal object PathAssertions {
       context("when Path points to a symlink that resolves to a nonexistent file") {
         fixture {
           val symlink = Files.createSymbolicLink(
-            directory.resolve("${it.fullName().joinToString(separator = "_")}_symlink"),
-            directory.resolve("${it.fullName().joinToString(separator = "_")}_nonexistent-target")
+            directory.resolve("${it.joinFullName()}_symlink"),
+            directory.resolve("${it.joinFullName()}_nonexistent-target")
           )
           expectThat(symlink)
         }
@@ -235,7 +238,7 @@ internal object PathAssertions {
   @TestFactory
   internal fun isDirectory(@TempDir directory: Path) = assertionTests<Path> {
     context("when subject Path is a regular file") {
-      fixture { expectThat(Files.createFile(directory.resolve(it.fullName().joinToString(separator = "_")))) }
+      fixture { expectThat(Files.createFile(directory.resolve(it.joinFullName()))) }
       test("assertion fails") {
         assertThrows<AssertionError> {
           isDirectory()
@@ -244,7 +247,7 @@ internal object PathAssertions {
     }
 
     context("when subject Path is a directory") {
-      fixture { expectThat(Files.createDirectory(directory.resolve(it.fullName().joinToString(separator = "_")))) }
+      fixture { expectThat(Files.createDirectory(directory.resolve(it.joinFullName()))) }
       test("assertion passes") {
         isDirectory()
       }
@@ -255,8 +258,8 @@ internal object PathAssertions {
         fixture {
           expectThat(
             Files.createSymbolicLink(
-              directory.resolve("${it.fullName().joinToString(separator = "_")}_link"),
-              Files.createFile(directory.resolve("${it.fullName().joinToString(separator = "_")}_target"))
+              directory.resolve("${it.joinFullName()}_link"),
+              Files.createFile(directory.resolve("${it.joinFullName()}_target"))
             )
           )
         }
@@ -271,8 +274,8 @@ internal object PathAssertions {
         fixture {
           expectThat(
             Files.createSymbolicLink(
-              directory.resolve("${it.fullName().joinToString(separator = "_")}_link"),
-              Files.createDirectory(directory.resolve(it.fullName().joinToString(separator = "_")))
+              directory.resolve("${it.joinFullName()}_link"),
+              Files.createDirectory(directory.resolve(it.joinFullName()))
             )
           )
         }
@@ -294,7 +297,7 @@ internal object PathAssertions {
       fixture {
         expectThat(
           Files.createFile(
-            directory.resolve(it.fullName().joinToString(separator = "_")),
+            directory.resolve(it.joinFullName()),
             PosixFilePermissions.asFileAttribute(setOf(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_EXECUTE))
           )
         )
@@ -308,7 +311,7 @@ internal object PathAssertions {
       fixture {
         expectThat(
           Files.createFile(
-            directory.resolve(it.fullName().joinToString(separator = "_")),
+            directory.resolve(it.joinFullName()),
             PosixFilePermissions.asFileAttribute(setOf(PosixFilePermission.OWNER_READ))
           )
         )
@@ -334,7 +337,7 @@ internal object PathAssertions {
   @TestFactory
   internal fun isRegularFile(@TempDir directory: Path) = assertionTests<Path> {
     context("when subject is a regular file") {
-      fixture { expectThat(Files.createFile(directory.resolve(it.fullName().joinToString(separator = "_")))) }
+      fixture { expectThat(Files.createFile(directory.resolve(it.joinFullName()))) }
       test("then assertion passes when no link options are provided") {
         isRegularFile()
       }
@@ -345,7 +348,7 @@ internal object PathAssertions {
     }
 
     context("subject is a directory") {
-      fixture { expectThat(Files.createDirectory(directory.resolve(it.fullName().joinToString(separator = "_")))) }
+      fixture { expectThat(Files.createDirectory(directory.resolve(it.joinFullName()))) }
       test("then assertion fails") {
         assertThrows<AssertionError> {
           isRegularFile()
@@ -357,7 +360,7 @@ internal object PathAssertions {
   @TestFactory
   internal fun isSymbolicLink(@TempDir directory: Path) = assertionTests<Path> {
     context("subject does not exist") {
-      fixture { expectThat(directory.resolve(it.fullName().joinToString(separator = "_"))) }
+      fixture { expectThat(directory.resolve(it.joinFullName())) }
       test("then assertion fails") {
         assertThrows<AssertionError> {
           isSymbolicLink()
@@ -366,7 +369,7 @@ internal object PathAssertions {
     }
 
     context("subject is a regular file") {
-      fixture { expectThat(Files.createFile(directory.resolve(it.fullName().joinToString(separator = "_")))) }
+      fixture { expectThat(Files.createFile(directory.resolve(it.joinFullName()))) }
       test("then assertion fails") {
         assertThrows<AssertionError> {
           isSymbolicLink()
@@ -379,8 +382,8 @@ internal object PathAssertions {
         fixture {
           expectThat(
             Files.createSymbolicLink(
-              directory.resolve("${it.fullName().joinToString(separator = "_")}_symlink"),
-              Files.createFile(directory.resolve("${it.fullName().joinToString(separator = "_")}_target"))
+              directory.resolve("${it.joinFullName()}_symlink"),
+              Files.createFile(directory.resolve("${it.joinFullName()}_target"))
             )
           )
         }
@@ -393,8 +396,8 @@ internal object PathAssertions {
         fixture {
           expectThat(
             Files.createSymbolicLink(
-              directory.resolve("${it.fullName().joinToString(separator = "_")}_symlink"),
-              directory.resolve("${it.fullName().joinToString(separator = "_")}_target")
+              directory.resolve("${it.joinFullName()}_symlink"),
+              directory.resolve("${it.joinFullName()}_target")
             )
           )
         }
@@ -410,7 +413,7 @@ internal object PathAssertions {
   internal fun allLines(@TempDir directory: Path) = assertionTests<Path> {
     context("subject is an empty file") {
       fixture {
-        expectThat(Files.createFile(directory.resolve(it.fullName().joinToString(separator = "_"))))
+        expectThat(Files.createFile(directory.resolve(it.joinFullName())))
       }
       test("then allLines() maps to an empty list") {
         allLines()
@@ -424,7 +427,7 @@ internal object PathAssertions {
 
     context("subject is a single line file") {
       fixture {
-        expectThat(Files.write(directory.resolve(it.fullName().joinToString(separator = "_")), listOf("first line")))
+        expectThat(Files.write(directory.resolve(it.joinFullName()), listOf("first line")))
       }
 
       test("then allLines() maps to a singleton list of the line") {
@@ -444,7 +447,7 @@ internal object PathAssertions {
     context("subject is an empty file") {
       fixture {
         expectThat(
-          Files.createFile(directory.resolve(it.fullName().joinToString(separator = "_")))
+          Files.createFile(directory.resolve(it.joinFullName()))
         )
       }
       test("then size maps to a 0 ") {
@@ -456,7 +459,7 @@ internal object PathAssertions {
     context("subject is a 4-byte file") {
       fixture {
         expectThat(
-          Files.write(Files.createFile(directory.resolve(it.fullName().joinToString(separator = "_"))), byteArrayOf(1, 2, 3, 4))
+          Files.write(Files.createFile(directory.resolve(it.joinFullName())), byteArrayOf(1, 2, 3, 4))
         )
       }
       test("then size maps to a 4") {


### PR DESCRIPTION
### Notes

* Made use of `@TempDirectory` for creating a directory for the whole test context, but didn't come up with a good way to handle it with `minutest` dynamic tests in a test context all have the same injected directory
* Still learning `minutest` best practices
* Only did a subset of the `Files` and `File` APIs that I have been using
* A few `File`-like testing extensions from https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.io/java.io.-file/index.html are included