### PR TITLE
Add spring ResponseEntity status code assertions

### DIFF
--- a/site/src/orchid/resources/data.yml
+++ b/site/src/orchid/resources/data.yml
@@ -15,3 +15,5 @@ contributors:
   link: https://github.com/christophsturm
 - name: Danny Thomas
   link: https://github.com/DanielThomas
+- name: Steven Van Bael
+  link: https://github.com/vbsteven

--- a/strikt-spring/src/main/kotlin/strikt/spring/ResponseEntity.kt
+++ b/strikt-spring/src/main/kotlin/strikt/spring/ResponseEntity.kt
@@ -1,0 +1,66 @@
+package strikt.spring
+
+import org.springframework.http.ResponseEntity
+import strikt.api.Assertion
+
+
+/**
+ * Asserts that the status code is a 1xx Information response.
+ */
+fun <T> Assertion.Builder<ResponseEntity<T>>.statusCodeIs1xxInformational(): Assertion.Builder<ResponseEntity<T>> =
+  assert("Status code is 1xx Informational") {
+    if (it.statusCode.is1xxInformational) pass() else {
+      (fail("status code is ${it.statusCode.value()}"))
+    }
+  }
+
+/**
+ * Asserts that the status code is a 2xx Success response.
+ */
+fun <T> Assertion.Builder<ResponseEntity<T>>.statusCodeIs2xxSuccess(): Assertion.Builder<ResponseEntity<T>> =
+  assert("Status code is 2xx success") {
+    if (it.statusCode.is2xxSuccessful) pass() else {
+      (fail("status code is ${it.statusCode.value()}"))
+    }
+  }
+
+
+/**
+ * Asserts that the status code is a 3xx Redirect response.
+ */
+fun <T> Assertion.Builder<ResponseEntity<T>>.statusCodeIs3xxRedirection(): Assertion.Builder<ResponseEntity<T>> =
+  assert("Status code is 3xx Redirection") {
+    if (it.statusCode.is3xxRedirection) pass() else {
+      (fail("status code is ${it.statusCode.value()}"))
+    }
+  }
+
+/**
+ * Asserts that the status code is a 4xx Client Error response.
+ */
+fun <T> Assertion.Builder<ResponseEntity<T>>.statusCodeIs4xxClientError(): Assertion.Builder<ResponseEntity<T>> =
+  assert("Status code is 4xx Client Error") {
+    if (it.statusCode.is4xxClientError) pass() else {
+      (fail("status code is ${it.statusCode.value()}"))
+    }
+  }
+
+/**
+ * Asserts that the status code is a 5xx Server Error response.
+ */
+fun <T> Assertion.Builder<ResponseEntity<T>>.statusCodeIs5xxServerError(): Assertion.Builder<ResponseEntity<T>> =
+  assert("Status code is 5xx Client Error") {
+    if (it.statusCode.is5xxServerError) pass() else {
+      (fail("status code is ${it.statusCode.value()}"))
+    }
+  }
+
+/**
+ * Asserts that the status code is equal to [expected].
+ */
+fun <T> Assertion.Builder<ResponseEntity<T>>.statusCodeIs(code: Int): Assertion.Builder<ResponseEntity<T>> =
+  assert("Status code is $code") {
+    if (it.statusCode.value() == code) pass() else {
+      (fail("status code is ${it.statusCode.value()}"))
+    }
+  }

--- a/strikt-spring/src/test/kotlin/strikt/spring/ResponseEntityAssertions.kt
+++ b/strikt-spring/src/test/kotlin/strikt/spring/ResponseEntityAssertions.kt
@@ -1,0 +1,151 @@
+package strikt.spring
+
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import org.junit.jupiter.api.assertThrows
+import org.opentest4j.AssertionFailedError
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import strikt.api.Assertion
+import strikt.api.expectThat
+import strikt.spring.app.Album
+
+internal class ResponseEntityAssertions : JUnit5Minutests {
+  private val album = Album("Almost Killed Me", 2004)
+
+  fun tests() = rootContext<Assertion.Builder<ResponseEntity<Album>>> {
+
+    context("statusCodeIs1xxInformational assertion") {
+      context("passes") {
+        fixture {
+          expectThat(ResponseEntity.status(HttpStatus.CONTINUE).body(album))
+        }
+
+        test("if status code is 1xx") {
+          statusCodeIs1xxInformational()
+        }
+      }
+      context("fails") {
+        fixture {
+          expectThat(ResponseEntity.ok(album))
+        }
+
+        test("if status code is not 1xx") {
+          assertThrows<AssertionFailedError> {
+            statusCodeIs1xxInformational()
+          }
+        }
+      }
+    }
+
+    context("statusCodeIs2xxSuccess assertion") {
+      context("passes") {
+        fixture {
+          expectThat(ResponseEntity.ok(album))
+        }
+
+        test("if status code is 2xx") {
+          statusCodeIs2xxSuccess()
+        }
+      }
+      context("fails") {
+        fixture {
+          expectThat(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(album))
+        }
+
+        test("if status code is not 2xx") {
+          assertThrows<AssertionFailedError> {
+            statusCodeIs2xxSuccess()
+          }
+        }
+      }
+    }
+
+    context("statusCodeIs3xxRedirect assertion") {
+      context("passes") {
+        fixture {
+          expectThat(ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY).body(album))
+        }
+
+        test("if status code is 3xx") {
+          statusCodeIs3xxRedirection()
+        }
+      }
+      context("fails") {
+        fixture {
+          expectThat(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(album))
+        }
+
+        test("if status code is not 3xx") {
+          assertThrows<AssertionFailedError> {
+            statusCodeIs3xxRedirection()
+          }
+        }
+      }
+    }
+
+    context("statusCodeIs4xxClientError assertion") {
+      context("passes") {
+        fixture {
+          expectThat(ResponseEntity.unprocessableEntity().body(album))
+        }
+
+        test("if status code is 4xx") {
+          statusCodeIs4xxClientError()
+        }
+      }
+      context("fails") {
+        fixture {
+          expectThat(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(album))
+        }
+
+        test("if status code is not 4xx") {
+          assertThrows<AssertionFailedError> {
+            statusCodeIs4xxClientError()
+          }
+        }
+      }
+    }
+
+    context("statusCodeIs5xxServerError assertion") {
+      context("passes") {
+        fixture {
+          expectThat(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(album))
+        }
+
+        test("if status code is 5xx") {
+          statusCodeIs5xxServerError()
+        }
+      }
+      context("fails") {
+        fixture {
+          expectThat(ResponseEntity.ok(album))
+        }
+
+        test("if status code is not 5xx") {
+          assertThrows<AssertionFailedError> {
+            statusCodeIs5xxServerError()
+          }
+        }
+      }
+    }
+
+    context("statusCodeIs assertion") {
+      fixture {
+        expectThat(ResponseEntity.ok(album))
+      }
+
+      test("passes if the status code is 200") {
+        statusCodeIs(200)
+      }
+
+      test("fails if the status code is not 200") {
+        assertThrows<AssertionFailedError> {
+          statusCodeIs(500)
+        }
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
In my integration tests I like to use `@SpringBootTest(webEnvironment=RANDOM_PORT)` together with the `TestRestTemplate` class so I can test the full security and error handling chain. The TestRestTemplate returns `ResponseEntity<T>` objects and this PR adds a few Strikt assertions I use for verifying those responses.

The tests are a little repetitive with nested contexts because I couldn't figure out a cleaner way to organize them while keeping success and failure cases close.
