### PR TITLE
⇡ Dokka version, remove usage of `delegateClosureOf` and use static a…

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-  compile("org.jetbrains.dokka:dokka-gradle-plugin:0.9.17")
+  compile("org.jetbrains.dokka:dokka-gradle-plugin:0.9.18")
   compile("com.netflix.nebula:nebula-publishing-plugin:9.4.6")
   compile("com.netflix.nebula:nebula-bintray-plugin:5.0.0")
   compile("com.ferranpons:twitter-gradle-plugin:1.1.0")

--- a/strikt-jackson/strikt-jackson.gradle.kts
+++ b/strikt-jackson/strikt-jackson.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.dokka.DokkaConfiguration.ExternalDocumentationLink
-import org.jetbrains.dokka.gradle.DokkaTask
 import java.net.URL
 
 plugins {
@@ -18,8 +16,8 @@ dependencies {
   testImplementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.9.8")
 }
 
-val dokka by tasks.getting(DokkaTask::class) {
-  externalDocumentationLink(delegateClosureOf<ExternalDocumentationLink.Builder> {
+tasks.dokka {
+  externalDocumentationLink {
     url = URL("https://fasterxml.github.io/jackson-databind/javadoc/2.9/")
-  })
+  }
 }

--- a/strikt-protobuf/strikt-protobuf.gradle.kts
+++ b/strikt-protobuf/strikt-protobuf.gradle.kts
@@ -3,8 +3,6 @@
 import com.google.protobuf.gradle.ExecutableLocator
 import com.google.protobuf.gradle.ProtobufConfigurator
 import com.google.protobuf.gradle.ProtobufConfigurator.JavaGenerateProtoTaskCollection
-import org.jetbrains.dokka.DokkaConfiguration.ExternalDocumentationLink
-import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import java.net.URL
 
@@ -21,11 +19,10 @@ dependencies {
   api("com.google.protobuf:protobuf-java:3.7.0")
 }
 
-val dokka by tasks.getting(DokkaTask::class) {
-  externalDocumentationLink(delegateClosureOf<ExternalDocumentationLink.Builder> {
-    url =
-      URL("https://developers.google.com/protocol-buffers/docs/reference/java/")
-  })
+tasks.dokka {
+  externalDocumentationLink {
+    url = URL("https://developers.google.com/protocol-buffers/docs/reference/java/")
+  }
 }
 
 protobuf {

--- a/strikt-spring/strikt-spring.gradle.kts
+++ b/strikt-spring/strikt-spring.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.dokka.DokkaConfiguration.ExternalDocumentationLink
-import org.jetbrains.dokka.gradle.DokkaTask
 import java.net.URL
 
 plugins {
@@ -24,9 +22,8 @@ dependencies {
   testImplementation("org.springframework.boot:spring-boot-starter-web")
 }
 
-val dokka by tasks.getting(DokkaTask::class) {
-  externalDocumentationLink(delegateClosureOf<ExternalDocumentationLink.Builder> {
-    url =
-      URL("https://docs.spring.io/spring-framework/docs/current/javadoc-api/")
-  })
+tasks.dokka {
+  externalDocumentationLink {
+    url = URL("https://docs.spring.io/spring-framework/docs/current/javadoc-api/")
+  }
 }


### PR DESCRIPTION
…ccessors for `dokka` task in each project