### PR TITLE
Add in array empty assertions for each array

### DIFF
--- a/strikt-core/src/main/kotlin/strikt/assertions/Arrays.kt
+++ b/strikt-core/src/main/kotlin/strikt/assertions/Arrays.kt
@@ -12,6 +12,14 @@ fun <T> Assertion.Builder<Array<out T>>.contentEquals(other: Array<out T>): Asse
   }
 
 /**
+ * Asserts that the subject's content is empty.
+ * @see Array.isEmpty
+ */
+@JvmName("isObjectArrayEmpty")
+fun <T> Assertion.Builder<Array<T>>.isEmpty(): Assertion.Builder<Array<T>> =
+  assertThat("array is empty") { it.isEmpty() }
+
+/**
  * Asserts that the subject's content is equal to that of [other] according to
  * [BooleanArray.contentEquals].
  */
@@ -19,6 +27,14 @@ fun Assertion.Builder<BooleanArray>.contentEquals(other: BooleanArray): Assertio
   assertThat("array content equals %s", other) {
     it.contentEquals(other)
   }
+
+/**
+ * Asserts that the subject's content is empty.
+ * @see Array.isEmpty
+ */
+@JvmName("isBooleanArrayEmpty")
+fun Assertion.Builder<BooleanArray>.isEmpty(): Assertion.Builder<BooleanArray> =
+  assertThat("array is empty") { it.isEmpty() }
 
 /**
  * Asserts that the subject's content is equal to that of [other] according to
@@ -30,6 +46,14 @@ fun Assertion.Builder<ByteArray>.contentEquals(other: ByteArray): Assertion.Buil
   }
 
 /**
+ * Asserts that the subject's content is empty.
+ * @see Array.isEmpty
+ */
+@JvmName("isByteArrayEmpty")
+fun Assertion.Builder<ByteArray>.isEmpty(): Assertion.Builder<ByteArray> =
+  assertThat("array is empty") { it.isEmpty() }
+
+/**
  * Asserts that the subject's content is equal to that of [other] according to
  * [ShortArray.contentEquals].
  */
@@ -37,6 +61,14 @@ fun Assertion.Builder<ShortArray>.contentEquals(other: ShortArray): Assertion.Bu
   assertThat("array content equals %s", other) {
     it.contentEquals(other)
   }
+
+/**
+ * Asserts that the subject's content is empty.
+ * @see Array.isEmpty
+ */
+@JvmName("isShortArrayEmpty")
+fun Assertion.Builder<ShortArray>.isEmpty(): Assertion.Builder<ShortArray> =
+  assertThat("array is empty") { it.isEmpty() }
 
 /**
  * Asserts that the subject's content is equal to that of [other] according to
@@ -48,6 +80,14 @@ fun Assertion.Builder<IntArray>.contentEquals(other: IntArray): Assertion.Builde
   }
 
 /**
+ * Asserts that the subject's content is empty.
+ * @see Array.isEmpty
+ */
+@JvmName("isIntArrayEmpty")
+fun Assertion.Builder<IntArray>.isEmpty(): Assertion.Builder<IntArray> =
+  assertThat("array is empty") { it.isEmpty() }
+
+/**
  * Asserts that the subject's content is equal to that of [other] according to
  * [LongArray.contentEquals].
  */
@@ -55,6 +95,14 @@ fun Assertion.Builder<LongArray>.contentEquals(other: LongArray): Assertion.Buil
   assertThat("array content equals %s", other) {
     it.contentEquals(other)
   }
+
+/**
+ * Asserts that the subject's content is empty.
+ * @see Array.isEmpty
+ */
+@JvmName("isLongArrayEmpty")
+fun Assertion.Builder<LongArray>.isEmpty(): Assertion.Builder<LongArray> =
+  assertThat("array is empty") { it.isEmpty() }
 
 /**
  * Asserts that the subject's content is equal to that of [other] according to
@@ -66,6 +114,14 @@ fun Assertion.Builder<FloatArray>.contentEquals(other: FloatArray): Assertion.Bu
   }
 
 /**
+ * Asserts that the subject's content is empty.
+ * @see Array.isEmpty
+ */
+@JvmName("isFloatArrayEmpty")
+fun Assertion.Builder<FloatArray>.isEmpty(): Assertion.Builder<FloatArray> =
+  assertThat("array is empty") { it.isEmpty() }
+
+/**
  * Asserts that the subject's content is equal to that of [other] according to
  * [DoubleArray.contentEquals].
  */
@@ -75,6 +131,14 @@ fun Assertion.Builder<DoubleArray>.contentEquals(other: DoubleArray): Assertion.
   }
 
 /**
+ * Asserts that the subject's content is empty.
+ * @see Array.isEmpty
+ */
+@JvmName("isDoubleArrayEmpty")
+fun Assertion.Builder<DoubleArray>.isEmpty(): Assertion.Builder<DoubleArray> =
+  assertThat("array is empty") { it.isEmpty() }
+
+/**
  * Asserts that the subject's content is equal to that of [other] according to
  * [CharArray.contentEquals].
  */
@@ -82,6 +146,14 @@ fun Assertion.Builder<CharArray>.contentEquals(other: CharArray): Assertion.Buil
   assertThat("array content equals %s", other) {
     it.contentEquals(other)
   }
+
+/**
+ * Asserts that the subject's content is empty.
+ * @see Array.isEmpty
+ */
+@JvmName("is_ArrayEmpty")
+fun Assertion.Builder<CharArray>.isEmpty(): Assertion.Builder<CharArray> =
+  assertThat("array is empty") { it.isEmpty() }
 
 /**
  * Maps an array to a list to make it possible to use the iterable matchers

--- a/strikt-core/src/test/kotlin/strikt/assertions/ArrayAssertions.kt
+++ b/strikt-core/src/test/kotlin/strikt/assertions/ArrayAssertions.kt
@@ -77,6 +77,24 @@ internal object ArrayAssertions {
           }
         }
       }
+
+      context("isEmpty assertion") {
+        test("fails") {
+          assertThrows<AssertionFailedError> {
+            isEmpty()
+          }
+        }
+      }
+    }
+
+    context("an empty byte array") {
+      fixture { expectThat(byteArrayOf()) }
+
+      context("isEmpty assertion") {
+        test("passes") {
+          isEmpty()
+        }
+      }
     }
   }
 
@@ -143,6 +161,24 @@ internal object ArrayAssertions {
           }
         }
       }
+
+      context("isEmpty assertion") {
+        test("fails") {
+          assertThrows<AssertionFailedError> {
+            isEmpty()
+          }
+        }
+      }
+    }
+
+    context("an empty character array") {
+      fixture { expectThat(charArrayOf()) }
+
+      context("isEmpty assertion") {
+        test("passes") {
+          isEmpty()
+        }
+      }
     }
   }
 
@@ -150,11 +186,31 @@ internal object ArrayAssertions {
   fun `boolean arrays`() = assertionTests<BooleanArray> {
     val subject = BooleanArray(8) { it % 2 == 0 }
 
-    context("isEqualTo assertion") {
+    context("a boolean array containing ${subject.contentToString()}") {
       fixture { expectThat(subject) }
 
-      test("passes for a copy of itself") {
-        isEqualTo(subject.copyOf())
+      context("isEqualTo assertion") {
+        test("passes for a copy of itself") {
+          isEqualTo(subject.copyOf())
+        }
+      }
+
+      context("isEmpty assertion") {
+        test("fails") {
+          assertThrows<AssertionFailedError> {
+            isEmpty()
+          }
+        }
+      }
+    }
+
+    context("an empty boolean array") {
+      fixture { expectThat(booleanArrayOf()) }
+
+      context("isEmpty assertion") {
+        test("passes") {
+          isEmpty()
+        }
       }
     }
   }
@@ -163,11 +219,31 @@ internal object ArrayAssertions {
   fun `short arrays`() = assertionTests<ShortArray> {
     val subject = shortArrayOf(1, 2, 4, 8, 16, 32, 64, 128)
 
-    context("isEqualTo assertion") {
+    context("a short array containing ${subject.contentToString()}") {
       fixture { expectThat(subject) }
 
-      test("passes for a copy of itself") {
-        isEqualTo(subject.copyOf())
+      context("isEqualTo assertion") {
+        test("passes for a copy of itself") {
+          isEqualTo(subject.copyOf())
+        }
+      }
+
+      context("isEmpty assertion") {
+        test("fails") {
+          assertThrows<AssertionFailedError> {
+            isEmpty()
+          }
+        }
+      }
+    }
+
+    context("an empty short array") {
+      fixture { expectThat(shortArrayOf()) }
+
+      context("isEmpty assertion") {
+        test("passes") {
+          isEmpty()
+        }
       }
     }
   }
@@ -176,11 +252,30 @@ internal object ArrayAssertions {
   fun `int arrays`() = assertionTests<IntArray> {
     val subject = intArrayOf(1, 2, 4, 8, 16, 32, 64, 128)
 
-    context("isEqualTo assertion") {
+    context("an int array containing ${subject.contentToString()}") {
       fixture { expectThat(subject) }
 
-      test("passes for a copy of itself") {
-        isEqualTo(subject.copyOf())
+      context("isEqualTo assertion") {
+        test("passes for a copy of itself") {
+          isEqualTo(subject.copyOf())
+        }
+      }
+
+      context("isEmpty assertion") {
+        test("fails") {
+          assertThrows<AssertionFailedError> {
+            isEmpty()
+          }
+        }
+      }
+    }
+
+    context("an empty int array") {
+      fixture { expectThat(intArrayOf()) }
+      context("isEmpty assertion") {
+        test("passes") {
+          isEmpty()
+        }
       }
     }
   }
@@ -189,11 +284,31 @@ internal object ArrayAssertions {
   fun `long arrays`() = assertionTests<LongArray> {
     val subject = longArrayOf(1, 2, 4, 8, 16, 32, 64, 128)
 
-    context("isEqualTo assertion") {
+    context("a long array containing ${subject.contentToString()}") {
       fixture { expectThat(subject) }
 
-      test("passes for a copy of itself") {
-        isEqualTo(subject.copyOf())
+      context("isEqualTo assertion") {
+
+        test("passes for a copy of itself") {
+          isEqualTo(subject.copyOf())
+        }
+      }
+
+      context("isEmpty assertion") {
+        test("fails") {
+          assertThrows<AssertionFailedError> {
+            isEmpty()
+          }
+        }
+      }
+    }
+
+    context("an empty long array") {
+      fixture { expectThat(longArrayOf()) }
+      context("isEmpty assertion") {
+        test("passes") {
+          isEmpty()
+        }
       }
     }
   }
@@ -202,11 +317,31 @@ internal object ArrayAssertions {
   fun `float arrays`() = assertionTests<FloatArray> {
     val subject = floatArrayOf(4.2f, 128.3f, 64.5f, 32.9f)
 
-    context("isEqualTo assertion") {
+    context("a float array containing ${subject.contentToString()}") {
       fixture { expectThat(subject) }
 
-      test("passes for a copy of itself") {
-        isEqualTo(subject.copyOf())
+      context("isEqualTo assertion") {
+
+        test("passes for a copy of itself") {
+          isEqualTo(subject.copyOf())
+        }
+      }
+
+      context("isEmpty assertion") {
+        test("fails") {
+          assertThrows<AssertionFailedError> {
+            isEmpty()
+          }
+        }
+      }
+    }
+
+    context("an empty float array") {
+      fixture { expectThat(floatArrayOf()) }
+      context("isEmpty assertion") {
+        test("passes") {
+          isEmpty()
+        }
       }
     }
   }
@@ -215,11 +350,31 @@ internal object ArrayAssertions {
   fun `double arrays`() = assertionTests<DoubleArray> {
     val subject = doubleArrayOf(4.2, 128.3, 64.5, 32.9)
 
-    context("isEqualTo assertion") {
+    context("a double array containing ${subject.contentToString()}") {
       fixture { expectThat(subject) }
 
-      test("passes for a copy of itself") {
-        isEqualTo(subject.copyOf())
+      context("isEqualTo assertion") {
+
+        test("passes for a copy of itself") {
+          isEqualTo(subject.copyOf())
+        }
+      }
+
+      context("isEmpty assertion") {
+        test("fails") {
+          assertThrows<AssertionFailedError> {
+            isEmpty()
+          }
+        }
+      }
+    }
+
+    context("an empty double array") {
+      fixture { expectThat(doubleArrayOf()) }
+      context("isEmpty assertion") {
+        test("passes") {
+          isEmpty()
+        }
       }
     }
   }
@@ -228,11 +383,31 @@ internal object ArrayAssertions {
   fun `object arrays`() = assertionTests<Array<String>> {
     val subject = arrayOf("catflap", "rubberplant", "marzipan")
 
-    context("isEqualTo assertion") {
+    context("an object array containing ${subject.contentToString()}") {
       fixture { expectThat(subject) }
 
-      test("passes for a copy of itself") {
-        isEqualTo(subject.copyOf())
+      context("isEqualTo assertion") {
+
+        test("passes for a copy of itself") {
+          isEqualTo(subject.copyOf())
+        }
+      }
+
+      context("isEmpty assertion") {
+        test("fails") {
+          assertThrows<AssertionFailedError> {
+            isEmpty()
+          }
+        }
+      }
+    }
+
+    context("an empty object array") {
+      fixture { expectThat(arrayOf()) }
+      context("isEmpty assertion") {
+        test("passes") {
+          isEmpty()
+        }
       }
     }
   }


### PR DESCRIPTION
We can't use a trick here like `fun <T, A : Array<T>>` because `Array` can not be used as an upper bound.
So, we introduce a specialization for each array type.

The `@JvmName` are needed due to clashing overloads and with the only difference being the parameterized type.

closes https://github.com/robfletcher/strikt/issues/161