### PR TITLE
Align block assertion `catching` with current implementation which us…

### DIFF
--- a/site/src/orchid/resources/wiki/expecting-exceptions.md
+++ b/site/src/orchid/resources/wiki/expecting-exceptions.md
@@ -22,6 +22,13 @@ For example:
 
 {% codesnippet key='catching_exceptions_2' testClass='Assertions' %}
 
+## With block assertions
+
+`catching` is also supported inside of block assertions.
+The `catching` function returns a `Assertion.Builder<Try<T>>` mentioned above.
+
+{% codesnippet key='catching_exceptions_3' testClass='Assertions' %}
+
 ### Shorthand form
 
 You can also use the `expectThrows<E>(A)` function which is simply a shorthand for the `expectCatching` / `failed` / `isA<E>` combination.

--- a/strikt-core/src/main/kotlin/strikt/api/Expect.kt
+++ b/strikt-core/src/main/kotlin/strikt/api/Expect.kt
@@ -28,8 +28,14 @@ fun expect(block: suspend ExpectationBuilder.() -> Unit) {
 
     override fun <T> catching(
       action: suspend () -> T
-    ): DescribeableBuilder<Result<T>> =
-      that(runCatching { runBlocking { action() } })
+    ): DescribeableBuilder<Try<T>> =
+      that(
+        try {
+          runBlocking { action() }.let(::Success)
+        } catch (e: Throwable) {
+          Failure(e)
+        }
+      )
   }
     .apply {
       runBlocking {

--- a/strikt-core/src/main/kotlin/strikt/api/ExpectationBuilder.kt
+++ b/strikt-core/src/main/kotlin/strikt/api/ExpectationBuilder.kt
@@ -34,5 +34,5 @@ interface ExpectationBuilder {
    * exception being thrown.
    * @return an assertion for the result of [action].
    */
-  fun <T> catching(action: suspend () -> T): DescribeableBuilder<Result<T>>
+  fun <T> catching(action: suspend () -> T): DescribeableBuilder<Try<T>>
 }

--- a/strikt-core/src/test/kotlin/strikt/docs/Assertions.kt
+++ b/strikt-core/src/test/kotlin/strikt/docs/Assertions.kt
@@ -161,7 +161,7 @@ internal class Assertions {
 // expecting-exceptions.md
 // -----------------------------------------------------------------------------
 
-  @Test fun `catching exceptions 1, 2`() {
+  @Test fun `catching exceptions 1, 2, 3`() {
     // START catching_exceptions_1
     expectCatching { identifyHotdog("hamburger") }
       .failed()
@@ -172,6 +172,19 @@ internal class Assertions {
     expectCatching { identifyHotdog("hotdog") }
       .succeeded()
     // END catching_exceptions_2
+
+    // START catching_exceptions_3
+    expect {
+      catching { identifyHotdog("hamburger") }
+        .failed()
+        .isA<NotHotdogException>()
+
+      catching { identifyHotdog("hotdog") }
+        .succeeded()
+    }
+    expectCatching { identifyHotdog("hotdog") }
+      .succeeded()
+    // END catching_exceptions_3
   }
 
   @Test fun `expect_throws 1`() {


### PR DESCRIPTION
…es internal `Try` class and update `expecting-exceptions.md` documentation to mention it

Right now, the `catching {}` function returns the Kotlin built-in `Result<T>` type which has no core assertion builders.