### PR TITLE
Fixes issue with `and` assertion not being applied correctly. Fixes #176

### DIFF
--- a/strikt-core/src/main/kotlin/strikt/internal/AssertionBuilder.kt
+++ b/strikt-core/src/main/kotlin/strikt/internal/AssertionBuilder.kt
@@ -38,8 +38,8 @@ internal class AssertionBuilder<T>(
           .also {
             strategy.evaluate(nestedContext)
           }
-        // return the original context and AssertionStrategy for chaining
-        AssertionBuilder(context, strategy)
+        // return the original builder for chaining
+        this
       }
 
   override fun not(assertions: Builder<T>.() -> Unit): Builder<T> {

--- a/strikt-core/src/main/kotlin/strikt/internal/AssertionBuilder.kt
+++ b/strikt-core/src/main/kotlin/strikt/internal/AssertionBuilder.kt
@@ -32,11 +32,14 @@ internal class AssertionBuilder<T>(
   ): Builder<T> =
     AssertionChainedGroup(context, context.subject)
       .let { nestedContext ->
+        // collect assertions from a child block
         AssertionBuilder(nestedContext, Collecting)
           .apply(assertions)
           .also {
             strategy.evaluate(nestedContext)
           }
+        // return the original context and AssertionStrategy for chaining
+        AssertionBuilder(context, strategy)
       }
 
   override fun not(assertions: Builder<T>.() -> Unit): Builder<T> {

--- a/strikt-core/src/test/kotlin/strikt/Chained.kt
+++ b/strikt-core/src/test/kotlin/strikt/Chained.kt
@@ -8,6 +8,7 @@ import org.opentest4j.AssertionFailedError
 import strikt.api.expectThat
 import strikt.assertions.contains
 import strikt.assertions.containsExactly
+import strikt.assertions.hasLength
 import strikt.assertions.isA
 import strikt.assertions.isEqualTo
 import strikt.assertions.isLowerCase
@@ -94,5 +95,64 @@ internal class Chained {
         .trimMargin(),
       error.message
     )
+  }
+
+  @Test
+  fun `and { } and { }`() {
+    assertThrows<AssertionError> {
+      expectThat("one")
+        .and {
+          isEqualTo("one")
+        }
+        .and {
+          isEqualTo("two")
+        }
+    }
+  }
+
+  @Test
+  fun `and { } assert()`() {
+    assertThrows<AssertionError> {
+      expectThat("one")
+        .and {
+          isEqualTo("one")
+        }
+        .isEqualTo("two")
+    }
+  }
+
+  @Test
+  fun `assert() and { }`() {
+    assertThrows<AssertionError> {
+      expectThat("one")
+        .isEqualTo("one")
+        .and {
+          isEqualTo("two")
+        }
+    }
+  }
+
+  @Test
+  fun `assert() assert()`() {
+    assertThrows<AssertionError> {
+      expectThat("one")
+        .isEqualTo("one")
+        .isEqualTo("two")
+    }
+  }
+
+  @Test
+  fun `many nested 'and { }'`() {
+    assertThrows<AssertionError> {
+      expectThat("one")
+        .and {
+          isEqualTo("one")
+          and { hasLength(3) }
+        }
+        .and {
+          isEqualTo("two")
+          and { hasLength(4) }
+        }
+    }
   }
 }


### PR DESCRIPTION
I believe this is the root cause for #176. The `and` assertion was returning `AssertionBuilder(nestedContext, Collecting)` from the `.let { }` block, which meant that any assertions downstream from that `.and` call were being collected instead of thrown.

By returning a separate builder with the original context (which is `Throwing` at the top-level`) things seem to be working again. 