### PR TITLE
Add Arrow Validated assertion

### DIFF
--- a/strikt-arrow/src/main/kotlin/strikt/arrow/validated/Validated.kt
+++ b/strikt-arrow/src/main/kotlin/strikt/arrow/validated/Validated.kt
@@ -1,0 +1,37 @@
+package strikt.arrow.validated
+
+import arrow.core.Validated
+import strikt.api.Assertion
+
+@Suppress("UNCHECKED_CAST")
+fun <E, A> Assertion.Builder<Validated<E, A>>.isValid() =
+  assert("should be Valid") {
+    it.fold({ fail() }, { pass() })
+  } as Assertion.Builder<Validated.Valid<A>>
+
+
+@Suppress("UNCHECKED_CAST")
+fun <E, A> Assertion.Builder<Validated<E, A>>.isValid(value: A) =
+  assert("should be Valid") {
+    it.fold({ fail() }, { if (it == value) pass() else fail() })
+  } as Assertion.Builder<Validated.Valid<A>>
+
+val <A> Assertion.Builder<Validated.Valid<A>>.a: Assertion.Builder<A>
+  @JvmName("validatedValid")
+  get() = get("valid value") { a }
+
+@Suppress("UNCHECKED_CAST")
+fun <E, A> Assertion.Builder<Validated<E, A>>.isInvalid() =
+  assert("should be Invalid") {
+    it.fold({ pass() }, { fail() })
+  } as Assertion.Builder<Validated.Invalid<E>>
+
+@Suppress("UNCHECKED_CAST")
+fun <E, A> Assertion.Builder<Validated<E, A>>.isInvalid(value: E) =
+  assert("should be Valid") {
+    it.fold({ if (it == value) pass() else fail() }, { fail() })
+  } as Assertion.Builder<Validated.Invalid<E>>
+
+val <E> Assertion.Builder<Validated.Invalid<E>>.e: Assertion.Builder<E>
+  @JvmName("validatedInvalid")
+  get() = get("invalid value") { e }

--- a/strikt-arrow/src/test/kotlin/strikt/arrow/MyTuple.kt
+++ b/strikt-arrow/src/test/kotlin/strikt/arrow/MyTuple.kt
@@ -1,3 +1,3 @@
-package strikt.arrow.either
+package strikt.arrow
 
 data class MyTuple(val name: String, val id: Long?, val uuid: String?)

--- a/strikt-arrow/src/test/kotlin/strikt/arrow/validated/ValidatedAssertions.kt
+++ b/strikt-arrow/src/test/kotlin/strikt/arrow/validated/ValidatedAssertions.kt
@@ -1,6 +1,7 @@
-package strikt.arrow.either
+package strikt.arrow.validated
 
-import arrow.core.Either
+import arrow.core.invalid
+import arrow.core.valid
 import dev.minutest.junit.testFactoryFor
 import dev.minutest.rootContext
 import org.junit.jupiter.api.DisplayName
@@ -13,58 +14,56 @@ import strikt.assertions.isNotBlank
 import strikt.assertions.isNotNull
 
 @DisplayName("assertions on Either")
-object EitherAssertions {
+object ValidatedAssertions {
 
   @TestFactory
-  fun leftEither() = testFactoryFor(rootContext<Unit> {
-
-    val anEither = Either.left("left")
+  fun invalidValidated() = testFactoryFor(rootContext<Unit> {
+    val aValidated = "invalid".invalid()
 
     test("can assert on type") {
-      expectThat(anEither).isLeft()
+      expectThat(aValidated).isInvalid()
     }
 
     test("can assert on type and value equality") {
-      expectThat(anEither).isLeft("left")
+      expectThat(aValidated).isInvalid("invalid")
     }
 
     test("can assert on type and traverse unwrapped value") {
-      expectThat(anEither).isLeft().a.isEqualTo("left")
+      expectThat(aValidated).isInvalid().e.isEqualTo("invalid")
     }
 
     test("can have nested assertions on unwrapped value") {
-      expectThat(Either.left(MyTuple("myName", 1, "uuid"))).isLeft().a.and {
+      expectThat(MyTuple("myName", 1, "uuid").invalid()).isInvalid().e.and {
         get { name }.isEqualTo("myName")
         get { id }.isNotNull().isGreaterThan(0L)
         get { uuid }.isNotNull().isNotBlank()
       }
     }
+
   })
-
-  @TestFactory
-  fun rightEither() = testFactoryFor(rootContext<Unit> {
-
-    val anEither = Either.right("right")
+ @TestFactory
+  fun validValidated() = testFactoryFor(rootContext<Unit> {
+    val aValidated = "valid".valid()
 
     test("can assert on type") {
-      expectThat(anEither).isRight()
+      expectThat(aValidated).isValid()
     }
 
     test("can assert on type and value equality") {
-      expectThat(anEither).isRight("right")
+      expectThat(aValidated).isValid("valid")
     }
 
     test("can assert on type and traverse unwrapped value") {
-      expectThat(anEither).isRight().b.isEqualTo("right")
+      expectThat(aValidated).isValid().a.isEqualTo("valid")
     }
 
     test("can have nested assertions on unwrapped value") {
-      expectThat(Either.right(MyTuple("myName", 1, "uuid"))).isRight().b.and {
+      expectThat(MyTuple("myName", 1, "uuid").valid()).isValid().a.and {
         get { name }.isEqualTo("myName")
         get { id }.isNotNull().isGreaterThan(0L)
         get { uuid }.isNotNull().isNotBlank()
       }
     }
+
   })
 }
-


### PR DESCRIPTION
This PR is for adding assertion for `Validated` data type in `Arrow`. I use `fold` function instead of `when`, it looks more arrow IMHO.
I can work on adding more Arrow types.