### PR TITLE
Add assertions for sequence of values being present in a list

### DIFF
--- a/strikt-core/src/main/kotlin/strikt/assertions/List.kt
+++ b/strikt-core/src/main/kotlin/strikt/assertions/List.kt
@@ -1,6 +1,7 @@
 package strikt.assertions
 
 import strikt.api.Assertion.Builder
+import java.util.*
 
 /**
  * Maps this assertion to an assertion on the element at index [i] in the
@@ -17,3 +18,27 @@ operator fun <T : List<E>, E> Builder<T>.get(range: IntRange): Builder<List<E>> 
   get("elements [$range] %s") {
     subList(range.first, range.last + 1)
   }
+
+/**
+ * Asserts that all [elements] are present in the subject in exactly the same order
+ */
+fun <T : List<E>, E> Builder<T>.containsSequence(vararg elements: E) =
+  containsSequence(elements.toList())
+
+/**
+ * Asserts that all [elements] are present in the subject in exactly the same order
+ */
+fun <T : List<E>, E> Builder<T>.containsSequence(elements: List<E>) =
+  assert("contains the sequence: %s in exactly the same order", elements.toList()) { subject ->
+    val subjectList = subject.toList()
+    val expectedList = elements.toList()
+
+    when {
+      subjectList.isEmpty() -> fail("subject cannot be empty")
+      expectedList.isEmpty() -> fail("expected sequence cannot empty")
+      subjectList.size < expectedList.size -> fail("expected sequence cannot be longer than subject")
+      Collections.indexOfSubList(subjectList, expectedList) != -1 -> pass()
+      else -> fail()
+    }
+  }
+

--- a/strikt-core/src/test/kotlin/strikt/assertions/ListAssertions.kt
+++ b/strikt-core/src/test/kotlin/strikt/assertions/ListAssertions.kt
@@ -1,0 +1,69 @@
+package strikt.assertions
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.TestFactory
+import org.junit.jupiter.api.assertThrows
+import strikt.api.expectThat
+
+@DisplayName("assertions on List")
+internal object ListAssertions {
+
+
+  @TestFactory
+  @DisplayName("containsSequence assertion")
+  fun containsSequence() = assertionTests<List<Any?>> {
+    derivedContext<List<Int>>("a ${List::class}") {
+      fixture { listOf(1, 2, 3, 4) }
+      context("passes if") {
+        test("the subject contains the sequence") {
+          expectThat(fixture)
+            .containsSequence(3, 4)
+        }
+
+        test("the subject contains exactly the same elements as the expected sequence") {
+          expectThat(fixture)
+            .containsSequence(1, 2, 3, 4)
+        }
+      }
+
+      context("fails if") {
+        test("the subject does not contain the sequence in the same order") {
+          val exception = assertThrows<AssertionError> {
+            expectThat(fixture)
+              .containsSequence(1, 4)
+          }
+          assertEquals(
+            """▼ Expect that [1, 2, 3, 4]:
+            |  ✗ contains the sequence: [1, 4] in exactly the same order""".trimMargin(),
+            exception.message
+          )
+        }
+
+        test("the expected sequence is longer than the subject") {
+          val exception = assertThrows<AssertionError> {
+            expectThat(fixture)
+              .containsSequence(1, 2, 3, 4, 5)
+          }
+          assertEquals(
+            """▼ Expect that [1, 2, 3, 4]:
+            |  ✗ contains the sequence: [1, 2, 3, 4, 5] in exactly the same order : expected sequence cannot be longer than subject""".trimMargin(),
+            exception.message
+          )
+        }
+
+        test("the expected sequence is empty") {
+          val exception = assertThrows<AssertionError> {
+            expectThat(fixture)
+              .containsSequence()
+          }
+          assertEquals(
+            """▼ Expect that [1, 2, 3, 4]:
+            |  ✗ contains the sequence: [] in exactly the same order : expected sequence cannot empty""".trimMargin(),
+            exception.message
+          )
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Draft PR to add assertions for a sequence of values being present in a list (#156)

This PR doesn't do the non-contiguous version yet.

I'm a bit unsure of a couple of things, being my first contribution to this repo:
* Is it preferred to have this as a Collection or Iterable and not necessarily a List? I was confused about using a List or Collection/Iterable because then, unordered collections may be passed into the function.
* Is it okay to have it as a composed assertion? I defined a couple of sub-assertions, but I don't know if it's okay or even if the assertions make sense for the project. Some sub-assertions I made are:
    * subject is not empty
    * the expected sequence is not empty
    * subject is not longer than the expected sequence
    * subject does contain the sequence in exactly the same order

I will add the non-contiguous version: `containsSubsequence(ELEMENT... sequence)` once I'm familiar with what to do, or where to put the code.
