### PR TITLE
#185 Arrow module documentation fix

### DIFF
--- a/site/site.gradle.kts
+++ b/site/site.gradle.kts
@@ -43,7 +43,8 @@ orchid {
     ":strikt-jackson",
     ":strikt-java-time",
     ":strikt-protobuf",
-    ":strikt-spring"
+    ":strikt-spring",
+    ":strikt-arrow"
   ).map { project(it) }
 
   documentedModules.forEach {

--- a/strikt-arrow/src/main/kotlin/strikt/arrow/Either.kt
+++ b/strikt-arrow/src/main/kotlin/strikt/arrow/Either.kt
@@ -1,4 +1,4 @@
-package strikt.arrow.either
+package strikt.arrow
 
 import arrow.core.Either
 import strikt.api.Assertion

--- a/strikt-arrow/src/main/kotlin/strikt/arrow/Either.kt
+++ b/strikt-arrow/src/main/kotlin/strikt/arrow/Either.kt
@@ -3,6 +3,11 @@ package strikt.arrow
 import arrow.core.Either
 import strikt.api.Assertion
 
+/**
+ * Asserts that the [Either] is [Either.Right]
+ * @return Assertion builder over the same subject that is now known to be
+ * a [Either.Right].
+ */
 @Suppress("UNCHECKED_CAST")
 fun <L, R> Assertion.Builder<Either<L, R>>.isRight() =
   assert("should be Right") {
@@ -12,6 +17,12 @@ fun <L, R> Assertion.Builder<Either<L, R>>.isRight() =
     }
   } as Assertion.Builder<Either.Right<R>>
 
+/**
+ * Asserts that the [Either] is [Either.Right] and that it contains the exact value
+ * @param value Value to compare to the [Either]'s wrapped value
+ * @return Assertion builder over the same subject that is now known to be
+ * a [Either.Right].
+ */
 @Suppress("UNCHECKED_CAST")
 fun <L, R> Assertion.Builder<Either<L, R>>.isRight(value: R) =
   assert("should be Right($value)") {
@@ -26,10 +37,19 @@ fun <L, R> Assertion.Builder<Either<L, R>>.isRight(value: R) =
     }
   } as Assertion.Builder<Either.Right<R>>
 
+/**
+ * Unwraps the containing value of the [Either.Right]
+ * @return Assertion builder over the unwrapped subject
+ */
 val <R> Assertion.Builder<Either.Right<R>>.b: Assertion.Builder<R>
   @JvmName("eitherB")
   get() = get("right value") { b }
 
+/**
+ * Asserts that the [Either] is [Either.Left]
+ * @return Assertion builder over the same subject that is now known to be
+ * a [Either.Left].
+ */
 @Suppress("UNCHECKED_CAST")
 fun <L, R> Assertion.Builder<Either<L, R>>.isLeft() =
   assert("should be Left") {
@@ -39,6 +59,12 @@ fun <L, R> Assertion.Builder<Either<L, R>>.isLeft() =
     }
   } as Assertion.Builder<Either.Left<L>>
 
+/**
+ * Asserts that the [Either] is [Either.Left] and that it contains the exact value
+ * @param value Value to compare to the [Either]'s wrapped value
+ * @return Assertion builder over the same subject that is now known to be
+ * a [Either.Left].
+ */
 @Suppress("UNCHECKED_CAST")
 fun <L, R> Assertion.Builder<Either<L, R>>.isLeft(value: L) =
   assert("should be Left($value)") {
@@ -54,6 +80,10 @@ fun <L, R> Assertion.Builder<Either<L, R>>.isLeft(value: L) =
     }
   } as Assertion.Builder<Either.Left<L>>
 
+/**
+ * Unwraps the containing value of the [Either.Left]
+ * @return Assertion builder over the unwrapped subject
+ */
 val <L> Assertion.Builder<Either.Left<L>>.a: Assertion.Builder<L>
   @JvmName("eitherA")
   get() = get("left value") { a }

--- a/strikt-arrow/src/main/kotlin/strikt/arrow/Option.kt
+++ b/strikt-arrow/src/main/kotlin/strikt/arrow/Option.kt
@@ -5,6 +5,11 @@ import arrow.core.Option
 import arrow.core.Some
 import strikt.api.Assertion
 
+/**
+ * Asserts that the [Option] is [None]
+ * @return Assertion builder over the same subject that is now known to be
+ * a [None].
+ */
 @Suppress("UNCHECKED_CAST")
 fun <T> Assertion.Builder<Option<T>>.isNone() =
   assert("should be None") {
@@ -14,6 +19,11 @@ fun <T> Assertion.Builder<Option<T>>.isNone() =
     }
   } as Assertion.Builder<None>
 
+/**
+ * Asserts that the [Option] is [Some]
+ * @return Assertion builder over the same subject that is now known to be
+ * a [Some].
+ */
 @Suppress("UNCHECKED_CAST")
 fun <T> Assertion.Builder<Option<T>>.isSome() =
   assert("should be Some") {
@@ -23,6 +33,12 @@ fun <T> Assertion.Builder<Option<T>>.isSome() =
     }
   } as Assertion.Builder<Some<T>>
 
+/**
+ * Asserts that the [Option] is [Some] and that it contains the exact value
+ * @param value Value to compare to the [Option]'s wrapped value
+ * @return Assertion builder over the same subject that is now known to be
+ * a [Some].
+ */
 @Suppress("UNCHECKED_CAST")
 fun <T> Assertion.Builder<Option<T>>.isSome(value: T) =
   assert("should be Some($value)") {
@@ -38,5 +54,9 @@ fun <T> Assertion.Builder<Option<T>>.isSome(value: T) =
     }
   } as Assertion.Builder<Some<T>>
 
+/**
+ * Unwraps the containing value of the [Some]
+ * @return Assertion builder over the unwrapped subject
+ */
 val <T> Assertion.Builder<Some<T>>.t: Assertion.Builder<T>
   get() = get("some value") { t }

--- a/strikt-arrow/src/main/kotlin/strikt/arrow/Option.kt
+++ b/strikt-arrow/src/main/kotlin/strikt/arrow/Option.kt
@@ -1,4 +1,4 @@
-package strikt.arrow.option
+package strikt.arrow
 
 import arrow.core.None
 import arrow.core.Option

--- a/strikt-arrow/src/main/kotlin/strikt/arrow/Try.kt
+++ b/strikt-arrow/src/main/kotlin/strikt/arrow/Try.kt
@@ -1,4 +1,4 @@
-package strikt.arrow.`try`
+package strikt.arrow
 
 import arrow.core.Failure
 import arrow.core.Success

--- a/strikt-arrow/src/main/kotlin/strikt/arrow/Try.kt
+++ b/strikt-arrow/src/main/kotlin/strikt/arrow/Try.kt
@@ -5,6 +5,11 @@ import arrow.core.Success
 import arrow.core.Try
 import strikt.api.Assertion
 
+/**
+ * Asserts that the [Try] is [Success]
+ * @return Assertion builder over the same subject that is now known to be
+ * a [Success].
+ */
 @Suppress("UNCHECKED_CAST")
 fun <T> Assertion.Builder<Try<T>>.isSuccess() =
   assert("should be Success") {
@@ -14,6 +19,12 @@ fun <T> Assertion.Builder<Try<T>>.isSuccess() =
     }
   } as Assertion.Builder<Success<T>>
 
+/**
+ * Asserts that the [Try] is [Success] and that it contains the exact value
+ * @param value Value to compare to the [Try]'s wrapped value
+ * @return Assertion builder over the same subject that is now known to be
+ * a [Success].
+ */
 @Suppress("UNCHECKED_CAST")
 fun <T> Assertion.Builder<Try<T>>.isSuccess(value: T) =
   assert("should be Success($value)") {
@@ -29,9 +40,18 @@ fun <T> Assertion.Builder<Try<T>>.isSuccess(value: T) =
     }
   } as Assertion.Builder<Success<T>>
 
+/**
+ * Unwraps the containing value of the [Success]
+ * @return Assertion builder over the unwrapped subject
+ */
 val <T> Assertion.Builder<Success<T>>.value: Assertion.Builder<T>
   get() = get("success value") { value }
 
+/**
+ * Asserts that the [Try] is [Failure]
+ * @return Assertion builder over the same subject that is now known to be
+ * a [Failure].
+ */
 @Suppress("UNCHECKED_CAST")
 fun <T> Assertion.Builder<Try<T>>.isFailure() =
   assert("should be Failure") {
@@ -41,5 +61,9 @@ fun <T> Assertion.Builder<Try<T>>.isFailure() =
     }
   } as Assertion.Builder<Failure>
 
+/**
+ * Unwraps the containing [Throwable] value of the [Failure]
+ * @return Assertion builder over the unwrapped [Throwable]
+ */
 val Assertion.Builder<Failure>.exception: Assertion.Builder<Throwable>
   get() = get("failure exception") { exception }

--- a/strikt-arrow/src/main/kotlin/strikt/arrow/Validated.kt
+++ b/strikt-arrow/src/main/kotlin/strikt/arrow/Validated.kt
@@ -1,4 +1,4 @@
-package strikt.arrow.validated
+package strikt.arrow
 
 import arrow.core.Validated
 import strikt.api.Assertion

--- a/strikt-arrow/src/main/kotlin/strikt/arrow/Validated.kt
+++ b/strikt-arrow/src/main/kotlin/strikt/arrow/Validated.kt
@@ -3,35 +3,64 @@ package strikt.arrow
 import arrow.core.Validated
 import strikt.api.Assertion
 
+/**
+ * Asserts that the [Validated] is [Validated.Valid]
+ * @return Assertion builder over the same subject that is now known to be
+ * a [Validated.Valid].
+ */
 @Suppress("UNCHECKED_CAST")
 fun <E, A> Assertion.Builder<Validated<E, A>>.isValid() =
   assert("should be Valid") {
     it.fold({ fail() }, { pass() })
   } as Assertion.Builder<Validated.Valid<A>>
 
-
+/**
+ * Asserts that the [Validated] is [Validated.Valid] and that it contains the exact value
+ * @param value Value to compare to the [Validated]'s wrapped value
+ * @return Assertion builder over the same subject that is now known to be
+ * a [Validated.Valid].
+ */
 @Suppress("UNCHECKED_CAST")
 fun <E, A> Assertion.Builder<Validated<E, A>>.isValid(value: A) =
   assert("should be Valid") {
     it.fold({ fail() }, { if (it == value) pass() else fail() })
   } as Assertion.Builder<Validated.Valid<A>>
 
+/**
+ * Unwraps the containing value of the [Validated.Valid]
+ * @return Assertion builder over the unwrapped subject
+ */
 val <A> Assertion.Builder<Validated.Valid<A>>.a: Assertion.Builder<A>
   @JvmName("validatedValid")
   get() = get("valid value") { a }
 
+/**
+ * Asserts that the [Validated] is [Validated.Invalid]
+ * @return Assertion builder over the same subject that is now known to be
+ * a [Validated.Invalid].
+ */
 @Suppress("UNCHECKED_CAST")
 fun <E, A> Assertion.Builder<Validated<E, A>>.isInvalid() =
   assert("should be Invalid") {
     it.fold({ pass() }, { fail() })
   } as Assertion.Builder<Validated.Invalid<E>>
 
+/**
+ * Asserts that the [Validated] is [Validated.Invalid] and that it contains the exact value
+ * @param value Value to compare to the [Validated]'s wrapped value
+ * @return Assertion builder over the same subject that is now known to be
+ * a [Validated.Invalid].
+ */
 @Suppress("UNCHECKED_CAST")
 fun <E, A> Assertion.Builder<Validated<E, A>>.isInvalid(value: E) =
   assert("should be Valid") {
     it.fold({ if (it == value) pass() else fail() }, { fail() })
   } as Assertion.Builder<Validated.Invalid<E>>
 
+/**
+ * Unwraps the containing value of the [Validated.Invalid]
+ * @return Assertion builder over the unwrapped subject
+ */
 val <E> Assertion.Builder<Validated.Invalid<E>>.e: Assertion.Builder<E>
   @JvmName("validatedInvalid")
   get() = get("invalid value") { e }

--- a/strikt-arrow/src/test/kotlin/strikt/arrow/EitherAssertions.kt
+++ b/strikt-arrow/src/test/kotlin/strikt/arrow/EitherAssertions.kt
@@ -1,4 +1,4 @@
-package strikt.arrow.either
+package strikt.arrow
 
 import arrow.core.Either
 import dev.minutest.junit.testFactoryFor
@@ -6,7 +6,6 @@ import dev.minutest.rootContext
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.TestFactory
 import strikt.api.expectThat
-import strikt.arrow.MyTuple
 import strikt.assertions.isEqualTo
 import strikt.assertions.isGreaterThan
 import strikt.assertions.isNotBlank

--- a/strikt-arrow/src/test/kotlin/strikt/arrow/OptionAssertions.kt
+++ b/strikt-arrow/src/test/kotlin/strikt/arrow/OptionAssertions.kt
@@ -1,4 +1,4 @@
-package strikt.arrow.option
+package strikt.arrow
 
 import arrow.core.Option
 import dev.minutest.junit.testFactoryFor

--- a/strikt-arrow/src/test/kotlin/strikt/arrow/TryAssertions.kt
+++ b/strikt-arrow/src/test/kotlin/strikt/arrow/TryAssertions.kt
@@ -1,4 +1,4 @@
-package strikt.arrow.`try`
+package strikt.arrow
 
 import arrow.core.Try
 import dev.minutest.junit.testFactoryFor
@@ -6,9 +6,7 @@ import dev.minutest.rootContext
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.TestFactory
 import strikt.api.expectThat
-import strikt.assertions.isA
 import strikt.assertions.isEqualTo
-import strikt.assertions.isSameInstanceAs
 import strikt.assertions.message
 
 @DisplayName("assertions on Try")

--- a/strikt-arrow/src/test/kotlin/strikt/arrow/ValidatedAssertions.kt
+++ b/strikt-arrow/src/test/kotlin/strikt/arrow/ValidatedAssertions.kt
@@ -1,4 +1,4 @@
-package strikt.arrow.validated
+package strikt.arrow
 
 import arrow.core.invalid
 import arrow.core.valid
@@ -7,7 +7,6 @@ import dev.minutest.rootContext
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.TestFactory
 import strikt.api.expectThat
-import strikt.arrow.MyTuple
 import strikt.assertions.isEqualTo
 import strikt.assertions.isGreaterThan
 import strikt.assertions.isNotBlank
@@ -41,7 +40,8 @@ object ValidatedAssertions {
     }
 
   })
- @TestFactory
+
+  @TestFactory
   fun validValidated() = testFactoryFor(rootContext<Unit> {
     val aValidated = "valid".valid()
 


### PR DESCRIPTION
This PR is intended to fix #185 and will also create JavaDoc comments on the Assertions in the Arrow module.

The package (directory) of Arrow assertions had to be moved to the `strikt.arrow` which was specified in the documentation and module information, otherwise Orchid wouldn't pick up the classes/documentation (at least properly). Another approach would have been to modify the Orchid configuration just for this module, but since other modules like Spring, Time and Jackson also have Assertions in the base package, Arrow ones are moved to match the same structure.
