### PR TITLE
Bump Arrow version 0.10.3

### DIFF
--- a/strikt-arrow/strikt-arrow.gradle.kts
+++ b/strikt-arrow/strikt-arrow.gradle.kts
@@ -10,8 +10,8 @@ plugins {
 dependencies {
   api(project(":strikt-core"))
 
-  compileOnly("io.arrow-kt:arrow-core:0.10.0")
-  testImplementation("io.arrow-kt:arrow-core:0.10.0")
+  compileOnly("io.arrow-kt:arrow-core:0.10.3")
+  testImplementation("io.arrow-kt:arrow-core:0.10.3")
 
   testImplementation("dev.minutest:minutest:1.7.0")
 }


### PR DESCRIPTION
Bump Arrow version 0.10.3. This is the first stable version of Arrow 0.10.x.