### PR TITLE
feat: add Result assertions isFailure() and isSuccess()

### DIFF
--- a/strikt-core/src/main/kotlin/strikt/assertions/Throwable.kt
+++ b/strikt-core/src/main/kotlin/strikt/assertions/Throwable.kt
@@ -20,10 +20,69 @@ val <T : Throwable> Builder<T>.cause: DescribeableBuilder<Throwable?>
   get() = get(Throwable::cause)
 
 /**
+ * Asserts that the result of an action did throw an exception and maps to
+ * an assertion on the exception. The assertion fails if the subject's
+ * [Result.isFailure] returns `false`.
+ *
+ * @see runCatching
+ *
+ * @author [Bengt Brodersen](https://github.com/qoomon)
+ */
+fun <R> Builder<Result<R>>.isFailure(): Builder<Throwable> =
+  assert("is Failure") {
+    when {
+      it.isFailure -> pass()
+      else -> fail(
+        description = "returned %s",
+        actual = it.getOrThrow()
+      )
+    }
+  }
+    .get("exception") {
+      exceptionOrNull()!!
+    }
+
+/**
  * Asserts that the result of an action did not throw any exception and maps to
  * an assertion on the result value. The assertion fails if the subject's
- * [Result.isFailure] returns `true`.
+ * [Result.isSuccess] returns `false`.
+ *
+ * @see runCatching
+ *
+ * @author [Bengt Brodersen](https://github.com/qoomon)
  */
+fun <R> Builder<Result<R>>.isSuccess(): Builder<R> =
+  assert("is Success") {
+    when {
+      it.isSuccess -> pass()
+      else -> fail(
+        description = "threw %s",
+        actual = it.exceptionOrNull(),
+        cause = it.exceptionOrNull()
+      )
+    }
+  }
+    .get("value") {
+      // WORKAROUND - Handle inline class bug. (This will also work when this bug is fixed)
+      val value = getOrThrow()
+      if (value is Result<*>)
+        @Suppress("UNCHECKED_CAST")
+        return@get value.getOrThrow() as R
+      // WORKAROUND - END
+
+      getOrThrow()
+    }
+
+
+/**
+ * Deprecated form of [isSuccess]`()`.
+ *
+ * @see isSuccess()
+ */
+@Deprecated(
+  "Use isSuccess instead",
+  replaceWith = ReplaceWith("isSuccess()")
+)
 @Suppress("UNCHECKED_CAST")
 fun <R : Any> Builder<Result<R>>.doesNotThrow(): Builder<R> =
   assert("did not throw an exception") {

--- a/strikt-core/src/test/kotlin/strikt/assertions/ThrowableAssertions.kt
+++ b/strikt-core/src/test/kotlin/strikt/assertions/ThrowableAssertions.kt
@@ -1,0 +1,50 @@
+package strikt.assertions
+
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import org.junit.jupiter.api.assertThrows
+import org.opentest4j.AssertionFailedError
+import strikt.api.Assertion
+import strikt.api.expectThat
+
+internal object ThrowableAssertions : JUnit5Minutests {
+  fun isFailure() = rootContext<Assertion.Builder<Result<Int>>> {
+    context("the result subject is a failure") {
+      fixture { expectThat(Result.failure(Exception("boom"))) }
+
+      test("the assertion passes") {
+        isFailure().isA<Exception>().message.isEqualTo("boom")
+      }
+    }
+
+    context("the result subject is a success") {
+      fixture { expectThat(Result.success(42)) }
+
+      test("the assertion fails") {
+        assertThrows<AssertionFailedError> {
+          isFailure()
+        }
+      }
+    }
+  }
+
+  fun isSuccess() = rootContext<Assertion.Builder<Result<Int>>> {
+    context("the result subject is a success") {
+      fixture { expectThat(Result.success(42)) }
+
+      test("the assertion passes") {
+        isSuccess().isEqualTo(42)
+      }
+    }
+
+    context("the result subject is a failure") {
+      fixture { expectThat(Result.failure(Exception())) }
+
+      test("the assertion fails") {
+        assertThrows<AssertionFailedError> {
+          isSuccess()
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### Usage Examples

```kotlin
@Test
fun `divide by zero`() {
    // Given
   val numerator = 42
   val denominator = 0

    // When
    val result = runCatching{ subject.divide(numerator,  denominator) }

    // Then
    expectThat(result).isFailure().and {
        isA<IllegalArgumentException>()
        message.isEqualTo("Can't divide by zero")
    }
}
```

```kotlin
@Test
fun `divide by zero`() {
    // Given
   val numerator = 42
   val denominator = 2

    // When
    val result = runCatching{ subject.divide(numerator,  denominator) }

    // Then
    expectThat(result).isSuccess().and {
        isEqualTo(21)
    }
}
```
