### PR TITLE
Add more Builder<File> assertions

### DIFF
--- a/strikt-core/src/main/kotlin/strikt/assertions/File.kt
+++ b/strikt-core/src/main/kotlin/strikt/assertions/File.kt
@@ -1,5 +1,6 @@
 package strikt.assertions
 
+import strikt.api.Assertion
 import strikt.api.Assertion.Builder
 import java.io.File
 import java.nio.charset.Charset
@@ -21,6 +22,14 @@ val <T : File> Builder<T>.name: Builder<String>
  */
 val <T : File> Builder<T>.parent: Builder<String?>
   get() = get("parent", File::getParent)
+
+/**
+ * Maps this assertion to an assertion on the parent file or `null` if the subject does not have a parent.
+ *
+ * @see File.getParentFile
+ */
+val <T : File> Builder<T>.parentFile: Builder<File?>
+  get() = get(File::getParentFile)
 
 /**
  * Maps this assertion to an assertion on a path object representing this subject.
@@ -48,6 +57,22 @@ val <T : File> Builder<T>.nameWithoutExtension: Builder<String>
   get() = get("name without extension", File::nameWithoutExtension)
 
 /**
+ * Maps this assertion to an assertion on the [last modified][File.lastModified] of the subject.
+ *
+ * @see File.lastModified
+ */
+val <T : File> Builder<T>.lastModified: Builder<Long>
+  get() = get(File::lastModified)
+
+/**
+ * Maps this assertion to an assertion on the [file size][File.length] of the subject.
+ *
+ * @see File.length
+ */
+val <T : File> Builder<T>.length: Builder<Long>
+  get() = get(File::length)
+
+/**
  * Maps this assertion to an assertion on the lines of the subject decoded using the provided [charset].
  *
  * @param charset the charset used to decode the content
@@ -64,3 +89,175 @@ fun <T : File> Builder<T>.lines(charset: Charset = Charsets.UTF_8): Builder<List
  */
 fun <T : File> Builder<T>.text(charset: Charset = Charsets.UTF_8): Builder<String> =
   get("text (decoded with charset $charset)") { readText(charset) }
+
+/**
+ * Maps this assertion to an assertion on the [child files][File.listFiles] of the subject.
+ *
+ * Note: In contrast to [File.listFiles], an empty list is returned for non-directory files.
+ *
+ * @see File.listFiles
+ */
+val <T : File> Builder<T>.childFiles: Builder<List<File>>
+  get() = get("child files") { listFiles()?.toList() ?: emptyList() }
+
+/**
+ * Maps this assertion to an assertion on a specific child [name] of the subject.
+ */
+fun <T : File> Builder<T>.childFile(name: String): Builder<File> =
+  get("child $name") { File(this, name) }
+
+/**
+ * Asserts that the file exists.
+ *
+ * @see File.exists
+ */
+fun <T : File> Builder<T>.exists(): Builder<T> =
+  assert("exists") {
+    when {
+      it.exists() -> pass()
+      else -> fail()
+    }
+  }
+
+/**
+ * Asserts that the file not exists.
+ *
+ * @see File.exists
+ */
+fun <T : File> Builder<T>.notExists(): Builder<T> =
+  assert("not exists") {
+    when {
+      it.exists() -> fail()
+      else -> pass()
+    }
+  }
+
+/**
+ * Asserts that the file is a regular file.
+ *
+ * @see File.isFile
+ */
+fun <T : File> Builder<T>.isRegularFile(): Builder<T> =
+  assert("is a regular file") {
+    when {
+      it.isFile -> pass()
+      else -> fail()
+    }
+  }
+
+/**
+ * Asserts that the file is not a regular file.
+ *
+ * @see File.isFile
+ */
+fun <T : File> Builder<T>.isNotRegularFile(): Builder<T> =
+  assert("is not a regular file") {
+    when {
+      it.isFile -> fail()
+      else -> pass()
+    }
+  }
+
+/**
+ * Asserts that the file is a directory.
+ *
+ * @see File.isDirectory
+ */
+fun <T : File> Builder<T>.isDirectory(): Builder<T> =
+  assert("is a directory") {
+    when {
+      it.isDirectory -> pass()
+      else -> fail()
+    }
+  }
+
+/**
+ * Asserts that the file is not a directory.
+ *
+ * @see File.isDirectory
+ */
+fun <T : File> Builder<T>.isNotDirectory(): Builder<T> =
+  assert("is not a directory") {
+    when {
+      it.isDirectory -> fail()
+      else -> pass()
+    }
+  }
+
+/**
+ * Asserts that the file is readable.
+ *
+ * @see File.canRead
+ */
+fun <T : File> Builder<T>.isReadable(): Builder<T> =
+  assert("is readable") {
+    when {
+      it.canRead() -> pass()
+      else -> fail()
+    }
+  }
+
+/**
+ * Asserts that the file is not readable.
+ *
+ * @see File.canRead
+ */
+fun <T : File> Builder<T>.isNotReadable(): Builder<T> =
+  assert("is not readable") {
+    when {
+      it.canRead() -> fail()
+      else -> pass()
+    }
+  }
+
+/**
+ * Asserts that the file is writable.
+ *
+ * @see File.canWrite
+ */
+fun <T : File> Builder<T>.isWritable(): Builder<T> =
+  assert("is writable") {
+    when {
+      it.canWrite() -> pass()
+      else -> fail()
+    }
+  }
+
+/**
+ * Asserts that the file is not writable.
+ *
+ * @see File.canWrite
+ */
+fun <T : File> Builder<T>.isNotWritable(): Builder<T> =
+  assert("is not writable") {
+    when {
+      it.canWrite() -> fail()
+      else -> pass()
+    }
+  }
+
+/**
+ * Asserts that the file is executable.
+ *
+ * @see File.canExecute
+ */
+fun <T : File> Builder<T>.isExecutable(): Builder<T> =
+  assert("is executable") {
+    when {
+      it.canExecute() -> pass()
+      else -> fail()
+    }
+  }
+
+/**
+ * Asserts that the file is not executable.
+ *
+ * @see File.canExecute
+ */
+fun <T : File> Builder<T>.isNotExecutable(): Builder<T> =
+  assert("is not executable") {
+    when {
+      it.canExecute() -> fail()
+      else -> pass()
+    }
+  }

--- a/strikt-core/src/main/kotlin/strikt/assertions/File.kt
+++ b/strikt-core/src/main/kotlin/strikt/assertions/File.kt
@@ -29,7 +29,7 @@ val <T : File> Builder<T>.parent: Builder<String?>
  * @see File.getParentFile
  */
 val <T : File> Builder<T>.parentFile: Builder<File?>
-  get() = get(File::getParentFile)
+  get() = get("parentFile", File::getParentFile)
 
 /**
  * Maps this assertion to an assertion on a path object representing this subject.

--- a/strikt-core/src/test/kotlin/strikt/assertions/FileAssertions.kt
+++ b/strikt-core/src/test/kotlin/strikt/assertions/FileAssertions.kt
@@ -123,9 +123,13 @@ internal object FileAssertions : JUnit5Minutests {
 
     context("lastModified") {
       context("given the subject is a file with last modified") {
-        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile()).apply {
-          setLastModified(1602491019000L)
-        }) }
+        fixture {
+          expectThat(
+            File.createTempFile("example", ".txt", directory.toFile()).apply {
+              setLastModified(1602491019000L)
+            }
+          )
+        }
         test("then the mapped value is the last modified") {
           lastModified
             .isEqualTo(1602491019000L)
@@ -135,9 +139,13 @@ internal object FileAssertions : JUnit5Minutests {
 
     context("length") {
       context("given the subject is a file with length") {
-        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile()).apply {
-          writeBytes("Hello World".toByteArray(Charsets.US_ASCII)) // us-ascii enforce 1 byte per character
-        }) }
+        fixture {
+          expectThat(
+            File.createTempFile("example", ".txt", directory.toFile()).apply {
+              writeBytes("Hello World".toByteArray(Charsets.US_ASCII)) // us-ascii enforce 1 byte per character
+            }
+          )
+        }
         test("then the mapped value is the length") {
           length
             .isEqualTo(11L)
@@ -223,7 +231,11 @@ internal object FileAssertions : JUnit5Minutests {
 
     context("childFiles") {
       context("given the subject is a regular file") {
-        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile())) }
+        fixture {
+          expectThat(
+            File.createTempFile("example", ".txt", directory.toFile())
+          )
+        }
         test("then the mapped value is empty") {
           childFiles
             .isEmpty()
@@ -231,17 +243,21 @@ internal object FileAssertions : JUnit5Minutests {
       }
 
       context("given the subject is a directory") {
-        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile().apply {
-          File(this, "foo.txt").apply {
-            createNewFile()
-          }
-          File(this, "bar.zip").apply {
-            createNewFile()
-          }
-          File(this, "zap.tar").apply {
-            createNewFile()
-          }
-        }) }
+        fixture {
+          expectThat(
+            Files.createTempDirectory(directory, "example").toFile().apply {
+              File(this, "foo.txt").apply {
+                createNewFile()
+              }
+              File(this, "bar.zip").apply {
+                createNewFile()
+              }
+              File(this, "zap.tar").apply {
+                createNewFile()
+              }
+            }
+          )
+        }
         test("then the mapped value contains all children") {
           childFiles
             .map { it.name }
@@ -265,17 +281,21 @@ internal object FileAssertions : JUnit5Minutests {
       }
 
       context("given the subject is a directory") {
-        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile().apply {
-          File(this, "foo.txt").apply {
-            createNewFile()
-          }
-          File(this, "bar.zip").apply {
-            createNewFile()
-          }
-          File(this, "zap.tar").apply {
-            createNewFile()
-          }
-        }) }
+        fixture {
+          expectThat(
+            Files.createTempDirectory(directory, "example").toFile().apply {
+              File(this, "foo.txt").apply {
+                createNewFile()
+              }
+              File(this, "bar.zip").apply {
+                createNewFile()
+              }
+              File(this, "zap.tar").apply {
+                createNewFile()
+              }
+            }
+          )
+        }
         test("then the mapped value contains the children") {
           childFile("foo.txt")
             .and {
@@ -293,7 +313,11 @@ internal object FileAssertions : JUnit5Minutests {
 
     context("exists") {
       context("given the subject is a non-existing file") {
-        fixture { expectThat(File("example.txt")) }
+        fixture {
+          expectThat(
+            File("example.txt")
+          )
+        }
         test("then the assertion should fail") {
           assertThrows<AssertionFailedError> {
             exists()
@@ -302,7 +326,11 @@ internal object FileAssertions : JUnit5Minutests {
       }
 
       context("given the subject is an existing file") {
-        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile())) }
+        fixture {
+          expectThat(
+            File.createTempFile("example", ".txt", directory.toFile())
+          )
+        }
         test("then the assertion should pass") {
           exists()
         }
@@ -311,14 +339,22 @@ internal object FileAssertions : JUnit5Minutests {
 
     context("notExists") {
       context("given the subject is a non-existing file") {
-        fixture { expectThat(File("example.txt")) }
+        fixture {
+          expectThat(
+            File("example.txt")
+          )
+        }
         test("then the assertion should pass") {
           notExists()
         }
       }
 
       context("given the subject is an existing file") {
-        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile())) }
+        fixture {
+          expectThat(
+            File.createTempFile("example", ".txt", directory.toFile())
+          )
+        }
         test("then the assertion should fail") {
           assertThrows<AssertionFailedError> {
             notExists()
@@ -329,7 +365,11 @@ internal object FileAssertions : JUnit5Minutests {
 
     context("isRegularFile") {
       context("given the subject is a non-existing file") {
-        fixture { expectThat(File("example.txt")) }
+        fixture {
+          expectThat(
+            File("example.txt")
+          )
+        }
         test("then the assertion should fail") {
           assertThrows<AssertionFailedError> {
             isRegularFile()
@@ -338,14 +378,22 @@ internal object FileAssertions : JUnit5Minutests {
       }
 
       context("given the subject is an existing file") {
-        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile())) }
+        fixture {
+          expectThat(
+            File.createTempFile("example", ".txt", directory.toFile())
+          )
+        }
         test("then the assertion should pass") {
           isRegularFile()
         }
       }
 
       context("given the subject is an existing directory") {
-        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile()) }
+        fixture {
+          expectThat(
+            Files.createTempDirectory(directory, "example").toFile()
+          )
+        }
         test("then the assertion should fail") {
           assertThrows<AssertionFailedError> {
             isRegularFile()
@@ -356,14 +404,22 @@ internal object FileAssertions : JUnit5Minutests {
 
     context("isNotRegularFile") {
       context("given the subject is a non-existing file") {
-        fixture { expectThat(File("example.txt")) }
+        fixture {
+          expectThat(
+            File("example.txt")
+          )
+        }
         test("then the assertion should pass") {
           isNotRegularFile()
         }
       }
 
       context("given the subject is an existing file") {
-        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile())) }
+        fixture {
+          expectThat(
+            File.createTempFile("example", ".txt", directory.toFile())
+          )
+        }
         test("then the assertion should fail") {
           assertThrows<AssertionFailedError> {
             isNotRegularFile()
@@ -372,7 +428,11 @@ internal object FileAssertions : JUnit5Minutests {
       }
 
       context("given the subject is an existing directory") {
-        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile()) }
+        fixture {
+          expectThat(
+            Files.createTempDirectory(directory, "example").toFile()
+          )
+        }
         test("then the assertion should pass") {
           isNotRegularFile()
         }
@@ -381,7 +441,11 @@ internal object FileAssertions : JUnit5Minutests {
 
     context("isDirectory") {
       context("given the subject is a non-existing file") {
-        fixture { expectThat(File("example.txt")) }
+        fixture {
+          expectThat(
+            File("example.txt")
+          )
+        }
         test("then the assertion should fail") {
           assertThrows<AssertionFailedError> {
             isDirectory()
@@ -390,7 +454,11 @@ internal object FileAssertions : JUnit5Minutests {
       }
 
       context("given the subject is an existing file") {
-        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile())) }
+        fixture {
+          expectThat(
+            File.createTempFile("example", ".txt", directory.toFile())
+          )
+        }
         test("then the assertion should fail") {
           assertThrows<AssertionFailedError> {
             isDirectory()
@@ -399,7 +467,11 @@ internal object FileAssertions : JUnit5Minutests {
       }
 
       context("given the subject is an existing directory") {
-        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile()) }
+        fixture {
+          expectThat(
+            Files.createTempDirectory(directory, "example").toFile()
+          )
+        }
         test("then the assertion should pass") {
           isDirectory()
         }
@@ -408,21 +480,33 @@ internal object FileAssertions : JUnit5Minutests {
 
     context("isNotDirectory") {
       context("given the subject is a non-existing file") {
-        fixture { expectThat(File("example.txt")) }
+        fixture {
+          expectThat(
+            File("example.txt")
+          )
+        }
         test("then the assertion should pass") {
           isNotDirectory()
         }
       }
 
       context("given the subject is an existing file") {
-        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile())) }
+        fixture {
+          expectThat(
+            File.createTempFile("example", ".txt", directory.toFile())
+          )
+        }
         test("then the assertion should pass") {
           isNotDirectory()
         }
       }
 
       context("given the subject is an existing directory") {
-        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile()) }
+        fixture {
+          expectThat(
+            Files.createTempDirectory(directory, "example").toFile()
+          )
+        }
         test("then the assertion should fail") {
           assertThrows<AssertionFailedError> {
             isNotDirectory()
@@ -433,7 +517,11 @@ internal object FileAssertions : JUnit5Minutests {
 
     context("isReadable") {
       context("given the subject is a non-existing file") {
-        fixture { expectThat(File("example.txt")) }
+        fixture {
+          expectThat(
+            File("example.txt")
+          )
+        }
         test("then the assertion should fail") {
           assertThrows<AssertionFailedError> {
             isReadable()
@@ -442,64 +530,92 @@ internal object FileAssertions : JUnit5Minutests {
       }
 
       context("given the subject is an existing readable file") {
-        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile()).apply {
-          setReadable(true, false)
-        }) }
+        fixture {
+          expectThat(
+            File.createTempFile("example", ".txt", directory.toFile()).apply {
+              setReadable(true, false)
+            }
+          )
+        }
         test("then the assertion should pass") {
           isReadable()
         }
       }
 
       context("given the subject is an existing readable directory") {
-        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile().apply {
-          setReadable(true, false)
-        }) }
+        fixture {
+          expectThat(
+            Files.createTempDirectory(directory, "example").toFile().apply {
+              setReadable(true, false)
+            }
+          )
+        }
         test("then the assertion should pass") {
           isReadable()
         }
       }
 
       context("given the subject is an existing not readable file") {
-        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile()).apply {
-          setReadable(false, false)
-        }) }
+        fixture {
+          expectThat(
+            File.createTempFile("example", ".txt", directory.toFile()).apply {
+              setReadable(false, false)
+            }
+          )
+        }
         test("then the assertion should fail") {
           assertThrows<AssertionFailedError> {
             isReadable()
           }
         }
         after {
-          get { setReadable(true, false) }
+          get {
+            setReadable(true, false)
+          }
         }
       }
 
       context("given the subject is an existing not readable directory") {
-        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile().apply {
-          setReadable(false, false)
-        }) }
+        fixture {
+          expectThat(
+            Files.createTempDirectory(directory, "example").toFile().apply {
+              setReadable(false, false)
+            }
+          )
+        }
         test("then the assertion should fail") {
           assertThrows<AssertionFailedError> {
             isReadable()
           }
         }
         after {
-          get { setReadable(true, false) }
+          get {
+            setReadable(true, false)
+          }
         }
       }
     }
 
     context("isNotReadable") {
       context("given the subject is a non-existing file") {
-        fixture { expectThat(File("example.txt")) }
+        fixture {
+          expectThat(
+            File("example.txt")
+          )
+        }
         test("then the assertion should pass") {
           isNotReadable()
         }
       }
 
       context("given the subject is an existing readable file") {
-        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile()).apply {
-          setReadable(true, false)
-        }) }
+        fixture {
+          expectThat(
+            File.createTempFile("example", ".txt", directory.toFile()).apply {
+              setReadable(true, false)
+            }
+          )
+        }
         test("then the assertion should fail") {
           assertThrows<AssertionFailedError> {
             isNotReadable()
@@ -508,9 +624,13 @@ internal object FileAssertions : JUnit5Minutests {
       }
 
       context("given the subject is an existing readable directory") {
-        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile().apply {
-          setReadable(true, false)
-        }) }
+        fixture {
+          expectThat(
+            Files.createTempDirectory(directory, "example").toFile().apply {
+              setReadable(true, false)
+            }
+          )
+        }
         test("then the assertion should fail") {
           assertThrows<AssertionFailedError> {
             isNotReadable()
@@ -519,33 +639,49 @@ internal object FileAssertions : JUnit5Minutests {
       }
 
       context("given the subject is an existing not readable file") {
-        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile()).apply {
-          setReadable(false, false)
-        }) }
+        fixture {
+          expectThat(
+            File.createTempFile("example", ".txt", directory.toFile()).apply {
+              setReadable(false, false)
+            }
+          )
+        }
         test("then the assertion should pass") {
           isNotReadable()
         }
         after {
-          get { setReadable(true, false) }
+          get {
+            setReadable(true, false)
+          }
         }
       }
 
       context("given the subject is an existing not readable directory") {
-        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile().apply {
-          setReadable(false, false)
-        }) }
+        fixture {
+          expectThat(
+            Files.createTempDirectory(directory, "example").toFile().apply {
+              setReadable(false, false)
+            }
+          )
+        }
         test("then the assertion should pass") {
           isNotReadable()
         }
         after {
-          get { setReadable(true, false) }
+          get {
+            setReadable(true, false)
+          }
         }
       }
     }
 
     context("isWritable") {
       context("given the subject is a non-existing file") {
-        fixture { expectThat(File("example.txt")) }
+        fixture {
+          expectThat(
+            File("example.txt")
+          )
+        }
         test("then the assertion should fail") {
           assertThrows<AssertionFailedError> {
             isWritable()
@@ -554,27 +690,39 @@ internal object FileAssertions : JUnit5Minutests {
       }
 
       context("given the subject is an existing writable file") {
-        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile()).apply {
-          setWritable(true, false)
-        }) }
+        fixture {
+          expectThat(
+            File.createTempFile("example", ".txt", directory.toFile()).apply {
+              setWritable(true, false)
+            }
+          )
+        }
         test("then the assertion should pass") {
           isWritable()
         }
       }
 
       context("given the subject is an existing writable directory") {
-        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile().apply {
-          setWritable(true, false)
-        }) }
+        fixture {
+          expectThat(
+            Files.createTempDirectory(directory, "example").toFile().apply {
+              setWritable(true, false)
+            }
+          )
+        }
         test("then the assertion should pass") {
           isWritable()
         }
       }
 
       context("given the subject is an existing not writable file") {
-        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile()).apply {
-          setWritable(false, false)
-        }) }
+        fixture {
+          expectThat(
+            File.createTempFile("example", ".txt", directory.toFile()).apply {
+              setWritable(false, false)
+            }
+          )
+        }
         test("then the assertion should fail") {
           assertThrows<AssertionFailedError> {
             isWritable()
@@ -583,9 +731,13 @@ internal object FileAssertions : JUnit5Minutests {
       }
 
       context("given the subject is an existing not writable directory") {
-        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile().apply {
-          setWritable(false, false)
-        }) }
+        fixture {
+          expectThat(
+            Files.createTempDirectory(directory, "example").toFile().apply {
+              setWritable(false, false)
+            }
+          )
+        }
         test("then the assertion should fail") {
           assertThrows<AssertionFailedError> {
             isWritable()
@@ -596,16 +748,24 @@ internal object FileAssertions : JUnit5Minutests {
 
     context("isNotWritable") {
       context("given the subject is a non-existing file") {
-        fixture { expectThat(File("example.txt")) }
+        fixture {
+          expectThat(
+            File("example.txt")
+          )
+        }
         test("then the assertion should pass") {
           isNotWritable()
         }
       }
 
       context("given the subject is an existing writable file") {
-        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile()).apply {
-          setWritable(true, false)
-        }) }
+        fixture {
+          expectThat(
+            File.createTempFile("example", ".txt", directory.toFile()).apply {
+              setWritable(true, false)
+            }
+          )
+        }
         test("then the assertion should fail") {
           assertThrows<AssertionFailedError> {
             isNotWritable()
@@ -614,9 +774,13 @@ internal object FileAssertions : JUnit5Minutests {
       }
 
       context("given the subject is an existing writable directory") {
-        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile().apply {
-          setWritable(true, false)
-        }) }
+        fixture {
+          expectThat(
+            Files.createTempDirectory(directory, "example").toFile().apply {
+              setWritable(true, false)
+            }
+          )
+        }
         test("then the assertion should fail") {
           assertThrows<AssertionFailedError> {
             isNotWritable()
@@ -625,18 +789,26 @@ internal object FileAssertions : JUnit5Minutests {
       }
 
       context("given the subject is an existing not writable file") {
-        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile()).apply {
-          setWritable(false, false)
-        }) }
+        fixture {
+          expectThat(
+            File.createTempFile("example", ".txt", directory.toFile()).apply {
+              setWritable(false, false)
+            }
+          )
+        }
         test("then the assertion should pass") {
           isNotWritable()
         }
       }
 
       context("given the subject is an existing not writable directory") {
-        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile().apply {
-          setWritable(false, false)
-        }) }
+        fixture {
+          expectThat(
+            Files.createTempDirectory(directory, "example").toFile().apply {
+              setWritable(false, false)
+            }
+          )
+        }
         test("then the assertion should pass") {
           isNotWritable()
         }
@@ -645,7 +817,11 @@ internal object FileAssertions : JUnit5Minutests {
 
     context("isExecutable") {
       context("given the subject is a non-existing file") {
-        fixture { expectThat(File("example.txt")) }
+        fixture {
+          expectThat(
+            File("example.txt")
+          )
+        }
         test("then the assertion should fail") {
           assertThrows<AssertionFailedError> {
             isExecutable()
@@ -654,64 +830,92 @@ internal object FileAssertions : JUnit5Minutests {
       }
 
       context("given the subject is an existing executable file") {
-        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile()).apply {
-          setExecutable(true, false)
-        }) }
+        fixture {
+          expectThat(
+            File.createTempFile("example", ".txt", directory.toFile()).apply {
+              setExecutable(true, false)
+            }
+          )
+        }
         test("then the assertion should pass") {
           isExecutable()
         }
       }
 
       context("given the subject is an existing executable directory") {
-        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile().apply {
-          setExecutable(true, false)
-        }) }
+        fixture {
+          expectThat(
+            Files.createTempDirectory(directory, "example").toFile().apply {
+              setExecutable(true, false)
+            }
+          )
+        }
         test("then the assertion should pass") {
           isExecutable()
         }
       }
 
       context("given the subject is an existing not executable file") {
-        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile()).apply {
-          setExecutable(false, false)
-        }) }
+        fixture {
+          expectThat(
+            File.createTempFile("example", ".txt", directory.toFile()).apply {
+              setExecutable(false, false)
+            }
+          )
+        }
         test("then the assertion should fail") {
           assertThrows<AssertionFailedError> {
             isExecutable()
           }
         }
         after {
-          get { setExecutable(true, false) }
+          get {
+            setExecutable(true, false)
+          }
         }
       }
 
       context("given the subject is an existing not executable directory") {
-        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile().apply {
-          setExecutable(false, false)
-        }) }
+        fixture {
+          expectThat(
+            Files.createTempDirectory(directory, "example").toFile().apply {
+              setExecutable(false, false)
+            }
+          )
+        }
         test("then the assertion should fail") {
           assertThrows<AssertionFailedError> {
             isExecutable()
           }
         }
         after {
-          get { setExecutable(true, false) }
+          get {
+            setExecutable(true, false)
+          }
         }
       }
     }
 
     context("isNotExecutable") {
       context("given the subject is a non-existing file") {
-        fixture { expectThat(File("example.txt")) }
+        fixture {
+          expectThat(
+            File("example.txt")
+          )
+        }
         test("then the assertion should pass") {
           isNotExecutable()
         }
       }
 
       context("given the subject is an existing executable file") {
-        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile()).apply {
-          setExecutable(true, false)
-        }) }
+        fixture {
+          expectThat(
+            File.createTempFile("example", ".txt", directory.toFile()).apply {
+              setExecutable(true, false)
+            }
+          )
+        }
         test("then the assertion should fail") {
           assertThrows<AssertionFailedError> {
             isNotExecutable()
@@ -720,9 +924,13 @@ internal object FileAssertions : JUnit5Minutests {
       }
 
       context("given the subject is an existing executable directory") {
-        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile().apply {
-          setExecutable(true, false)
-        }) }
+        fixture {
+          expectThat(
+            Files.createTempDirectory(directory, "example").toFile().apply {
+              setExecutable(true, false)
+            }
+          )
+        }
         test("then the assertion should fail") {
           assertThrows<AssertionFailedError> {
             isNotExecutable()
@@ -731,29 +939,40 @@ internal object FileAssertions : JUnit5Minutests {
       }
 
       context("given the subject is an existing not executable file") {
-        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile()).apply {
-          setExecutable(false, false)
-        }) }
+        fixture {
+          expectThat(
+            File.createTempFile("example", ".txt", directory.toFile()).apply {
+              setExecutable(false, false)
+            }
+          )
+        }
         test("then the assertion should pass") {
           isNotExecutable()
         }
         after {
-          get { setExecutable(true, false) }
+          get {
+            setExecutable(true, false)
+          }
         }
       }
 
       context("given the subject is an existing not executable directory") {
-        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile().apply {
-          setExecutable(false, false)
-        }) }
+        fixture {
+          expectThat(
+            Files.createTempDirectory(directory, "example").toFile().apply {
+              setExecutable(false, false)
+            }
+          )
+        }
         test("then the assertion should pass") {
           isNotExecutable()
         }
         after {
-          get { setExecutable(true, false) }
+          get {
+            setExecutable(true, false)
+          }
         }
       }
     }
-
   }
 }

--- a/strikt-core/src/test/kotlin/strikt/assertions/FileAssertions.kt
+++ b/strikt-core/src/test/kotlin/strikt/assertions/FileAssertions.kt
@@ -4,7 +4,9 @@ import dev.minutest.TestDescriptor
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.io.TempDir
+import org.opentest4j.AssertionFailedError
 import strikt.api.Assertion
 import strikt.api.expectThat
 import java.io.File
@@ -57,6 +59,24 @@ internal object FileAssertions : JUnit5Minutests {
       }
     }
 
+    context("parentFile") {
+      context("subject parentFile exists") {
+        fixture { expectThat(File("parent", "child")) }
+        test("then parentFile maps to the parent file object") {
+          parentFile
+            .isEqualTo(File("parent"))
+        }
+      }
+
+      context("subject file is root") {
+        fixture { expectThat(File("/")) }
+        test("then parentFile maps to a null value") {
+          parentFile
+            .isNull()
+        }
+      }
+    }
+
     context("toPath") {
       fixture { expectThat(File("parent", "child")) }
       test("mapped value is a Path") {
@@ -97,6 +117,30 @@ internal object FileAssertions : JUnit5Minutests {
         test("then the mapped value is the filename") {
           nameWithoutExtension
             .isEqualTo("example")
+        }
+      }
+    }
+
+    context("lastModified") {
+      context("given the subject is a file with last modified") {
+        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile()).apply {
+          setLastModified(1602491019000L)
+        }) }
+        test("then the mapped value is the last modified") {
+          lastModified
+            .isEqualTo(1602491019000L)
+        }
+      }
+    }
+
+    context("length") {
+      context("given the subject is a file with length") {
+        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile()).apply {
+          writeBytes("Hello World".toByteArray(Charsets.US_ASCII)) // us-ascii enforce 1 byte per character
+        }) }
+        test("then the mapped value is the length") {
+          length
+            .isEqualTo(11L)
         }
       }
     }
@@ -176,5 +220,540 @@ internal object FileAssertions : JUnit5Minutests {
         }
       }
     }
+
+    context("childFiles") {
+      context("given the subject is a regular file") {
+        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile())) }
+        test("then the mapped value is empty") {
+          childFiles
+            .isEmpty()
+        }
+      }
+
+      context("given the subject is a directory") {
+        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile().apply {
+          File(this, "foo.txt").apply {
+            createNewFile()
+          }
+          File(this, "bar.zip").apply {
+            createNewFile()
+          }
+          File(this, "zap.tar").apply {
+            createNewFile()
+          }
+        }) }
+        test("then the mapped value contains all children") {
+          childFiles
+            .map { it.name }
+            .containsExactlyInAnyOrder("foo.txt", "bar.zip", "zap.tar")
+        }
+      }
+    }
+
+    context("childFile") {
+      context("given the subject is a regular file") {
+        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile())) }
+        test("then the mapped value is null") {
+          childFile("foo.txt")
+            .and {
+              name.isEqualTo("foo.txt")
+              parent.isNotNull()
+                .startsWith("example")
+                .endsWith(".txt")
+            }
+        }
+      }
+
+      context("given the subject is a directory") {
+        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile().apply {
+          File(this, "foo.txt").apply {
+            createNewFile()
+          }
+          File(this, "bar.zip").apply {
+            createNewFile()
+          }
+          File(this, "zap.tar").apply {
+            createNewFile()
+          }
+        }) }
+        test("then the mapped value contains the children") {
+          childFile("foo.txt")
+            .and {
+              name.isEqualTo("foo.txt")
+              parent.isNotNull()
+                .startsWith("example")
+                .endsWith(".txt")
+              assertThat("is an existing file") {
+                it.exists()
+              }
+            }
+        }
+      }
+    }
+
+    context("exists") {
+      context("given the subject is a non-existing file") {
+        fixture { expectThat(File("example.txt")) }
+        test("then the assertion should fail") {
+          assertThrows<AssertionFailedError> {
+            exists()
+          }
+        }
+      }
+
+      context("given the subject is an existing file") {
+        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile())) }
+        test("then the assertion should pass") {
+          exists()
+        }
+      }
+    }
+
+    context("notExists") {
+      context("given the subject is a non-existing file") {
+        fixture { expectThat(File("example.txt")) }
+        test("then the assertion should pass") {
+          notExists()
+        }
+      }
+
+      context("given the subject is an existing file") {
+        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile())) }
+        test("then the assertion should fail") {
+          assertThrows<AssertionFailedError> {
+            notExists()
+          }
+        }
+      }
+    }
+
+    context("isRegularFile") {
+      context("given the subject is a non-existing file") {
+        fixture { expectThat(File("example.txt")) }
+        test("then the assertion should fail") {
+          assertThrows<AssertionFailedError> {
+            isRegularFile()
+          }
+        }
+      }
+
+      context("given the subject is an existing file") {
+        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile())) }
+        test("then the assertion should pass") {
+          isRegularFile()
+        }
+      }
+
+      context("given the subject is an existing directory") {
+        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile()) }
+        test("then the assertion should fail") {
+          assertThrows<AssertionFailedError> {
+            isRegularFile()
+          }
+        }
+      }
+    }
+
+    context("isNotRegularFile") {
+      context("given the subject is a non-existing file") {
+        fixture { expectThat(File("example.txt")) }
+        test("then the assertion should pass") {
+          isNotRegularFile()
+        }
+      }
+
+      context("given the subject is an existing file") {
+        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile())) }
+        test("then the assertion should fail") {
+          assertThrows<AssertionFailedError> {
+            isNotRegularFile()
+          }
+        }
+      }
+
+      context("given the subject is an existing directory") {
+        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile()) }
+        test("then the assertion should pass") {
+          isNotRegularFile()
+        }
+      }
+    }
+
+    context("isDirectory") {
+      context("given the subject is a non-existing file") {
+        fixture { expectThat(File("example.txt")) }
+        test("then the assertion should fail") {
+          assertThrows<AssertionFailedError> {
+            isDirectory()
+          }
+        }
+      }
+
+      context("given the subject is an existing file") {
+        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile())) }
+        test("then the assertion should fail") {
+          assertThrows<AssertionFailedError> {
+            isDirectory()
+          }
+        }
+      }
+
+      context("given the subject is an existing directory") {
+        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile()) }
+        test("then the assertion should pass") {
+          isDirectory()
+        }
+      }
+    }
+
+    context("isNotDirectory") {
+      context("given the subject is a non-existing file") {
+        fixture { expectThat(File("example.txt")) }
+        test("then the assertion should pass") {
+          isNotDirectory()
+        }
+      }
+
+      context("given the subject is an existing file") {
+        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile())) }
+        test("then the assertion should pass") {
+          isNotDirectory()
+        }
+      }
+
+      context("given the subject is an existing directory") {
+        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile()) }
+        test("then the assertion should fail") {
+          assertThrows<AssertionFailedError> {
+            isNotDirectory()
+          }
+        }
+      }
+    }
+
+    context("isReadable") {
+      context("given the subject is a non-existing file") {
+        fixture { expectThat(File("example.txt")) }
+        test("then the assertion should fail") {
+          assertThrows<AssertionFailedError> {
+            isReadable()
+          }
+        }
+      }
+
+      context("given the subject is an existing readable file") {
+        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile()).apply {
+          setReadable(true, false)
+        }) }
+        test("then the assertion should pass") {
+          isReadable()
+        }
+      }
+
+      context("given the subject is an existing readable directory") {
+        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile().apply {
+          setReadable(true, false)
+        }) }
+        test("then the assertion should pass") {
+          isReadable()
+        }
+      }
+
+      context("given the subject is an existing not readable file") {
+        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile()).apply {
+          setReadable(false, false)
+        }) }
+        test("then the assertion should fail") {
+          assertThrows<AssertionFailedError> {
+            isReadable()
+          }
+        }
+        after {
+          get { setReadable(true, false) }
+        }
+      }
+
+      context("given the subject is an existing not readable directory") {
+        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile().apply {
+          setReadable(false, false)
+        }) }
+        test("then the assertion should fail") {
+          assertThrows<AssertionFailedError> {
+            isReadable()
+          }
+        }
+        after {
+          get { setReadable(true, false) }
+        }
+      }
+    }
+
+    context("isNotReadable") {
+      context("given the subject is a non-existing file") {
+        fixture { expectThat(File("example.txt")) }
+        test("then the assertion should pass") {
+          isNotReadable()
+        }
+      }
+
+      context("given the subject is an existing readable file") {
+        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile()).apply {
+          setReadable(true, false)
+        }) }
+        test("then the assertion should fail") {
+          assertThrows<AssertionFailedError> {
+            isNotReadable()
+          }
+        }
+      }
+
+      context("given the subject is an existing readable directory") {
+        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile().apply {
+          setReadable(true, false)
+        }) }
+        test("then the assertion should fail") {
+          assertThrows<AssertionFailedError> {
+            isNotReadable()
+          }
+        }
+      }
+
+      context("given the subject is an existing not readable file") {
+        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile()).apply {
+          setReadable(false, false)
+        }) }
+        test("then the assertion should pass") {
+          isNotReadable()
+        }
+        after {
+          get { setReadable(true, false) }
+        }
+      }
+
+      context("given the subject is an existing not readable directory") {
+        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile().apply {
+          setReadable(false, false)
+        }) }
+        test("then the assertion should pass") {
+          isNotReadable()
+        }
+        after {
+          get { setReadable(true, false) }
+        }
+      }
+    }
+
+    context("isWritable") {
+      context("given the subject is a non-existing file") {
+        fixture { expectThat(File("example.txt")) }
+        test("then the assertion should fail") {
+          assertThrows<AssertionFailedError> {
+            isWritable()
+          }
+        }
+      }
+
+      context("given the subject is an existing writable file") {
+        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile()).apply {
+          setWritable(true, false)
+        }) }
+        test("then the assertion should pass") {
+          isWritable()
+        }
+      }
+
+      context("given the subject is an existing writable directory") {
+        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile().apply {
+          setWritable(true, false)
+        }) }
+        test("then the assertion should pass") {
+          isWritable()
+        }
+      }
+
+      context("given the subject is an existing not writable file") {
+        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile()).apply {
+          setWritable(false, false)
+        }) }
+        test("then the assertion should fail") {
+          assertThrows<AssertionFailedError> {
+            isWritable()
+          }
+        }
+      }
+
+      context("given the subject is an existing not writable directory") {
+        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile().apply {
+          setWritable(false, false)
+        }) }
+        test("then the assertion should fail") {
+          assertThrows<AssertionFailedError> {
+            isWritable()
+          }
+        }
+      }
+    }
+
+    context("isNotWritable") {
+      context("given the subject is a non-existing file") {
+        fixture { expectThat(File("example.txt")) }
+        test("then the assertion should pass") {
+          isNotWritable()
+        }
+      }
+
+      context("given the subject is an existing writable file") {
+        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile()).apply {
+          setWritable(true, false)
+        }) }
+        test("then the assertion should fail") {
+          assertThrows<AssertionFailedError> {
+            isNotWritable()
+          }
+        }
+      }
+
+      context("given the subject is an existing writable directory") {
+        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile().apply {
+          setWritable(true, false)
+        }) }
+        test("then the assertion should fail") {
+          assertThrows<AssertionFailedError> {
+            isNotWritable()
+          }
+        }
+      }
+
+      context("given the subject is an existing not writable file") {
+        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile()).apply {
+          setWritable(false, false)
+        }) }
+        test("then the assertion should pass") {
+          isNotWritable()
+        }
+      }
+
+      context("given the subject is an existing not writable directory") {
+        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile().apply {
+          setWritable(false, false)
+        }) }
+        test("then the assertion should pass") {
+          isNotWritable()
+        }
+      }
+    }
+
+    context("isExecutable") {
+      context("given the subject is a non-existing file") {
+        fixture { expectThat(File("example.txt")) }
+        test("then the assertion should fail") {
+          assertThrows<AssertionFailedError> {
+            isExecutable()
+          }
+        }
+      }
+
+      context("given the subject is an existing executable file") {
+        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile()).apply {
+          setExecutable(true, false)
+        }) }
+        test("then the assertion should pass") {
+          isExecutable()
+        }
+      }
+
+      context("given the subject is an existing executable directory") {
+        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile().apply {
+          setExecutable(true, false)
+        }) }
+        test("then the assertion should pass") {
+          isExecutable()
+        }
+      }
+
+      context("given the subject is an existing not executable file") {
+        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile()).apply {
+          setExecutable(false, false)
+        }) }
+        test("then the assertion should fail") {
+          assertThrows<AssertionFailedError> {
+            isExecutable()
+          }
+        }
+        after {
+          get { setExecutable(true, false) }
+        }
+      }
+
+      context("given the subject is an existing not executable directory") {
+        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile().apply {
+          setExecutable(false, false)
+        }) }
+        test("then the assertion should fail") {
+          assertThrows<AssertionFailedError> {
+            isExecutable()
+          }
+        }
+        after {
+          get { setExecutable(true, false) }
+        }
+      }
+    }
+
+    context("isNotExecutable") {
+      context("given the subject is a non-existing file") {
+        fixture { expectThat(File("example.txt")) }
+        test("then the assertion should pass") {
+          isNotExecutable()
+        }
+      }
+
+      context("given the subject is an existing executable file") {
+        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile()).apply {
+          setExecutable(true, false)
+        }) }
+        test("then the assertion should fail") {
+          assertThrows<AssertionFailedError> {
+            isNotExecutable()
+          }
+        }
+      }
+
+      context("given the subject is an existing executable directory") {
+        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile().apply {
+          setExecutable(true, false)
+        }) }
+        test("then the assertion should fail") {
+          assertThrows<AssertionFailedError> {
+            isNotExecutable()
+          }
+        }
+      }
+
+      context("given the subject is an existing not executable file") {
+        fixture { expectThat(File.createTempFile("example", ".txt", directory.toFile()).apply {
+          setExecutable(false, false)
+        }) }
+        test("then the assertion should pass") {
+          isNotExecutable()
+        }
+        after {
+          get { setExecutable(true, false) }
+        }
+      }
+
+      context("given the subject is an existing not executable directory") {
+        fixture { expectThat(Files.createTempDirectory(directory, "example").toFile().apply {
+          setExecutable(false, false)
+        }) }
+        test("then the assertion should pass") {
+          isNotExecutable()
+        }
+        after {
+          get { setExecutable(true, false) }
+        }
+      }
+    }
+
   }
 }

--- a/strikt-core/src/test/kotlin/strikt/assertions/FileAssertions.kt
+++ b/strikt-core/src/test/kotlin/strikt/assertions/FileAssertions.kt
@@ -273,7 +273,9 @@ internal object FileAssertions : JUnit5Minutests {
           childFile("foo.txt")
             .and {
               name.isEqualTo("foo.txt")
-              parent.isNotNull()
+              parentFile
+                .isNotNull()
+                .name
                 .startsWith("example")
                 .endsWith(".txt")
             }
@@ -300,9 +302,10 @@ internal object FileAssertions : JUnit5Minutests {
           childFile("foo.txt")
             .and {
               name.isEqualTo("foo.txt")
-              parent.isNotNull()
+              parentFile
+                .isNotNull()
+                .name
                 .startsWith("example")
-                .endsWith(".txt")
               assertThat("is an existing file") {
                 it.exists()
               }


### PR DESCRIPTION
I've needed most of these recently. :sunglasses: 

- mapping property `Builder<File>.parentFile: Builder<File>`
- mapping property `Builder<File>.lastModified: Long`
- mapping property `Builder<File>.length: Long`
- mapping property `Builder<File>.childFiles: Builder<List<File>>`
- mapping function `Builder<File>.childFile(name): Builder<File>`
- assertion `Builder<File>.exists()`
- assertion `Builder<File>.notExists()`
- assertion `Builder<File>.isRegularFile()`
- assertion `Builder<File>.isNotRegularFile()`
- assertion `Builder<File>.isDirectory()`
- assertion `Builder<File>.isNotDirectory()`
- assertion `Builder<File>.isReadable()`
- assertion `Builder<File>.isNotReadable()`
- assertion `Builder<File>.isWritable()`
- assertion `Builder<File>.isNotWritable()`
- assertion `Builder<File>.isExecutable()`
- assertion `Builder<File>.isNotExecutable()`
