### PR TITLE
Add 'doesNotContainKey' and 'doesNotContainKeys' map assertions

### DIFF
--- a/strikt-core/src/main/kotlin/strikt/assertions/Map.kt
+++ b/strikt-core/src/main/kotlin/strikt/assertions/Map.kt
@@ -72,6 +72,17 @@ infix fun <T : Map<K, V>, K, V> Builder<T>.containsKey(key: K): Builder<T> =
   }
 
 /**
+ * Asserts that the subject map does not contain an entry indexed by [key]. Depending on
+ * the map implementation the value associated with [key] may be `null`. This
+ * assertion just tests for the nonexistence of the key.
+ */
+infix fun <T : Map<K, V>, K, V> Builder<T>.doesNotContainKey(key: K): Builder<T> =
+  assertThat("does not have an entry with the key %s", key) {
+    !it.containsKey(key)
+  }
+  
+
+/**
  * Asserts that the subject map contains entries for all [keys].
  */
 fun <T : Map<K, V>, K, V> Builder<T>.containsKeys(vararg keys: K): Builder<T> =
@@ -80,6 +91,16 @@ fun <T : Map<K, V>, K, V> Builder<T>.containsKeys(vararg keys: K): Builder<T> =
   } then {
     if (allPassed) pass() else fail()
   }
+
+/**
+ * Asserts that the subject map doesn't contain entries for all [keys].
+ */
+fun <T : Map<K, V>, K, V> Builder<T>.doesNotContainKeys(vararg keys: K): Builder<T> =
+compose("doesn't have entries with the keys %s", keys.toList()) {
+  keys.forEach { key -> doesNotContainKey(key) }
+} then {
+  if (allPassed) pass() else fail()
+}
 
 /**
  * Asserts that the subject map contains an entry indexed by [key] with a value

--- a/strikt-core/src/test/kotlin/strikt/assertions/MapAssertions.kt
+++ b/strikt-core/src/test/kotlin/strikt/assertions/MapAssertions.kt
@@ -75,6 +75,23 @@ internal object MapAssertions : JUnit5Minutests {
         }
       }
 
+      context("doesNotContainKey assertion") {
+        test("passes if the subject doesn't have a matching key") {
+          doesNotContainKey("bar")
+        }
+
+        test("fails if the subject does have a matching key") {
+          val error = assertThrows<AssertionError> {
+            doesNotContainKey("foo")
+          }
+          expectThat(error.message).isEqualTo(
+            """▼ Expect that {"foo"="bar", "baz"="fnord", "qux"="fnord"}:
+              |  ✗ does not have an entry with the key "foo""""
+              .trimMargin()
+          )
+        }
+      }
+
       context("containsKeys assertion") {
         test("passes if the subject has all the specified keys") {
           containsKeys("foo", "baz")
@@ -90,6 +107,26 @@ internal object MapAssertions : JUnit5Minutests {
               |    ✓ has an entry with the key "foo"
               |    ✗ has an entry with the key "bar"
               |    ✗ has an entry with the key "fnord""""
+              .trimMargin()
+          )
+        }
+      }
+
+      context("doesNotContainKeys assertion") {
+        test("passes if the subject does not have all the specified keys") {
+          doesNotContainKeys("bar", "fnord")
+        }
+
+        test("fails if the subject does have a matching key") {
+          val error = assertThrows<AssertionError> {
+            doesNotContainKeys("bar", "fnord", "foo")
+          }
+          expectThat(error.message).isEqualTo(
+            """▼ Expect that {"foo"="bar", "baz"="fnord", "qux"="fnord"}:
+              |  ✗ doesn't have entries with the keys ["bar", "fnord", "foo"]
+              |    ✓ does not have an entry with the key "bar"
+              |    ✓ does not have an entry with the key "fnord"
+              |    ✗ does not have an entry with the key "foo""""
               .trimMargin()
           )
         }


### PR DESCRIPTION
These are a couple assertions we've been using when we used `google/truth` and found no easy analogue when migrating some of our tests to `strikt`. Please consider this PR for these additional assertions.