### PR TITLE
Add isSameInstant that compares the moment in time

### DIFF
--- a/strikt-jvm/src/main/kotlin/strikt/java/time/TemporalAccessor.kt
+++ b/strikt-jvm/src/main/kotlin/strikt/java/time/TemporalAccessor.kt
@@ -56,6 +56,27 @@ infix fun <T : TemporalAccessor> Assertion.Builder<T>.isAfter(expected: Temporal
   }
 
 /**
+ * Asserts that the subject is after [expected].
+ *
+ * @throws java.time.DateTimeException if [expected] is not a compatible
+ * temporal type.
+ */
+infix fun <T : TemporalAccessor> Assertion.Builder<T>.isSameInstant(expected: TemporalAccessor): Assertion.Builder<T> =
+  assertThat("is same instant as %s", expected) {
+    when (it) {
+      is Instant -> it == Instant.from(expected)
+      is ChronoLocalDate -> it.isEqual(LocalDate.from(expected))
+      is LocalTime -> it == LocalTime.from(expected)
+      is MonthDay -> it == MonthDay.from(expected)
+      is OffsetTime -> it.isEqual(OffsetTime.from(expected))
+      is Year -> it == Year.from(expected)
+      is YearMonth -> it == YearMonth.from(expected)
+      is ZonedDateTime -> it.isEqual(ZonedDateTime.from(expected))
+      else -> throw UnsupportedOperationException("Strikt's isSameInstant does not (currently) support ${it.javaClass.simpleName}")
+    }
+  }
+
+/**
  * Maps an assertion on the subject to an assertion on the value of the
  * specified temporal field.
  *

--- a/strikt-jvm/src/main/kotlin/strikt/java/time/TemporalAccessor.kt
+++ b/strikt-jvm/src/main/kotlin/strikt/java/time/TemporalAccessor.kt
@@ -5,6 +5,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.MonthDay
+import java.time.OffsetDateTime
 import java.time.OffsetTime
 import java.time.Year
 import java.time.YearMonth
@@ -30,6 +31,7 @@ infix fun <T : TemporalAccessor> Assertion.Builder<T>.isBefore(expected: Tempora
       is Year -> it.isBefore(Year.from(expected))
       is YearMonth -> it.isBefore(YearMonth.from(expected))
       is ZonedDateTime -> it.isBefore(ZonedDateTime.from(expected))
+      is OffsetDateTime -> it.isBefore(OffsetDateTime.from(expected))
       else -> throw UnsupportedOperationException("Strikt's isBefore does not (currently) support ${it.javaClass.simpleName}")
     }
   }
@@ -51,12 +53,13 @@ infix fun <T : TemporalAccessor> Assertion.Builder<T>.isAfter(expected: Temporal
       is Year -> it.isAfter(Year.from(expected))
       is YearMonth -> it.isAfter(YearMonth.from(expected))
       is ZonedDateTime -> it.isAfter(ZonedDateTime.from(expected))
+      is OffsetDateTime -> it.isAfter(OffsetDateTime.from(expected))
       else -> throw UnsupportedOperationException("Strikt's isAfter does not (currently) support ${it.javaClass.simpleName}")
     }
   }
 
 /**
- * Asserts that the subject is after [expected].
+ * Asserts that the subject is the same moment in time as [expected].
  *
  * @throws java.time.DateTimeException if [expected] is not a compatible
  * temporal type.
@@ -72,6 +75,7 @@ infix fun <T : TemporalAccessor> Assertion.Builder<T>.isSameInstant(expected: Te
       is Year -> it == Year.from(expected)
       is YearMonth -> it == YearMonth.from(expected)
       is ZonedDateTime -> it.isEqual(ZonedDateTime.from(expected))
+      is OffsetDateTime -> it.isEqual(OffsetDateTime.from(expected))
       else -> throw UnsupportedOperationException("Strikt's isSameInstant does not (currently) support ${it.javaClass.simpleName}")
     }
   }

--- a/strikt-jvm/src/test/kotlin/strikt/java/time/TemporalAssertions.kt
+++ b/strikt-jvm/src/test/kotlin/strikt/java/time/TemporalAssertions.kt
@@ -12,6 +12,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.MonthDay
+import java.time.OffsetDateTime
 import java.time.OffsetTime
 import java.time.Year
 import java.time.YearMonth
@@ -29,10 +30,12 @@ internal class TemporalAssertions : JUnit5Minutests {
 
   companion object {
     val zone: ZoneId = ZoneId.of("America/Los_Angeles")
+    val offset: ZoneOffset = ZoneOffset.ofHours(6)
     val instant: Instant = LocalDateTime.of(2019, 11, 29, 16, 43)
       .atZone(zone)
       .toInstant()
     val local: ZonedDateTime = instant.atZone(zone)
+    val localOffset: OffsetDateTime = instant.atOffset(offset)
     val date: LocalDate = local.toLocalDate()
     val time: LocalTime = local.toLocalTime()
   }
@@ -56,7 +59,8 @@ internal class TemporalAssertions : JUnit5Minutests {
         Pair(OffsetTime.from(local), local.plusSeconds(1)),
         Pair(Year.from(date), date.plusYears(1)),
         Pair(YearMonth.from(date), date.plusMonths(1)),
-        local to local.plusDays(1)
+        local to local.plusDays(1),
+        Pair(localOffset, localOffset.plusNanos(1))
       ).forEach { (subject, expected) ->
         test("passes asserting $subject (${subject.javaClass.simpleName}) is before $expected (${expected.javaClass.simpleName})") {
           expectThat(subject).isBefore(expected)
@@ -89,7 +93,8 @@ internal class TemporalAssertions : JUnit5Minutests {
         Pair(Year.from(date), date.minusYears(1)),
         Pair(YearMonth.from(date), date),
         Pair(YearMonth.from(date), date.minusMonths(1)),
-        local to local.minusDays(1)
+        local to local.minusDays(1),
+        Pair(localOffset, localOffset.minusNanos(1))
       ).forEach { (subject, expected) ->
         test("fails asserting $subject (${subject.javaClass.simpleName}) is before $expected (${expected.javaClass.simpleName})") {
           assertThrows<AssertionFailedError> {
@@ -104,6 +109,52 @@ internal class TemporalAssertions : JUnit5Minutests {
         test("fails asserting $subject is before $expected") {
           assertThrows<DateTimeException> {
             expectThat(subject).isBefore(expected)
+          }
+        }
+      }
+    }
+
+    context("isSameInstant assertion") {
+      listOf<Pair<TemporalAccessor, TemporalAccessor>>(
+        Pair(instant, instant),
+        Pair(date, date),
+        Pair(JapaneseDate.from(date), date),
+        Pair(time, time),
+        Pair(MonthDay.from(date), MonthDay.from(date)),
+        Pair(local, local),
+        Pair(local, localOffset),
+        Pair(localOffset, localOffset),
+        Pair(localOffset, localOffset.withOffsetSameInstant(ZoneOffset.ofTotalSeconds(offset.totalSeconds + 3600))),
+        Pair(OffsetTime.from(local), OffsetTime.from(local)),
+        Pair(OffsetTime.from(local), local.toOffsetDateTime()),
+        Pair(OffsetTime.from(local), local),
+        Pair(Year.from(date), date),
+        Pair(YearMonth.from(date), date)
+      ).forEach { (subject, expected) ->
+        test("passes asserting $subject (${subject.javaClass.simpleName}) is the same instant as $expected (${expected.javaClass.simpleName})") {
+          expectThat(subject).isSameInstant(expected)
+        }
+      }
+
+      listOf<Pair<TemporalAccessor, TemporalAccessor>>(
+        Pair(instant, instant.plusNanos(1)),
+        Pair(date, date.plusDays(1)),
+        Pair(JapaneseDate.from(date), date.plusDays(1)),
+        Pair(time, time.plusNanos(1)),
+        Pair(MonthDay.from(date), MonthDay.from(date.plusDays(1))),
+        Pair(local, local.plusNanos(1)),
+        Pair(local, localOffset.plusNanos(1)),
+        Pair(localOffset, localOffset.plusNanos(1)),
+        Pair(localOffset, localOffset.withOffsetSameInstant(ZoneOffset.ofTotalSeconds(offset.totalSeconds + 3600)).plusNanos(1)),
+        Pair(OffsetTime.from(local), OffsetTime.from(local).plusNanos(1)),
+        Pair(OffsetTime.from(local), local.toOffsetDateTime().plusNanos(1)),
+        Pair(OffsetTime.from(local), local.plusNanos(1)),
+        Pair(Year.from(date), date.plusYears(1)),
+        Pair(YearMonth.from(date), date.plusMonths(1))
+      ).forEach { (subject, expected) ->
+        test("fails asserting $subject (${subject.javaClass.simpleName}) is the same instant as $expected (${expected.javaClass.simpleName})") {
+          assertThrows<AssertionFailedError> {
+            expectThat(subject).isSameInstant(expected)
           }
         }
       }
@@ -127,7 +178,8 @@ internal class TemporalAssertions : JUnit5Minutests {
         Pair(OffsetTime.from(local), local.minusSeconds(1)),
         Pair(Year.from(date), date.minusYears(1)),
         Pair(YearMonth.from(date), date.minusMonths(1)),
-        local to local.minusDays(1)
+        local to local.minusDays(1),
+        Pair(localOffset, localOffset.minusNanos(1))
       ).forEach { (subject, expected) ->
         test("passes asserting $subject (${subject.javaClass.simpleName}) is before $expected (${expected.javaClass.simpleName})") {
           expectThat(subject).isAfter(expected)
@@ -160,7 +212,8 @@ internal class TemporalAssertions : JUnit5Minutests {
         Pair(Year.from(date), date.plusYears(1)),
         Pair(YearMonth.from(date), date),
         Pair(YearMonth.from(date), date.plusMonths(1)),
-        local to local.plusDays(1)
+        local to local.plusDays(1),
+        Pair(localOffset, localOffset.plusNanos(1))
       ).forEach { (subject, expected) ->
         test("fails asserting $subject (${subject.javaClass.simpleName}) is before $expected (${expected.javaClass.simpleName})") {
           assertThrows<AssertionFailedError> {


### PR DESCRIPTION
Some `java.time` types that include a timezone compare the time and timezone in their equals implementations. So two times that represent the same moment in time, but with different timezones, will compare as not equal. They have an `isEqual` method that comapres the instant in time.