### PR TITLE
output collection instead of only collection size.

### DIFF
--- a/strikt-core/src/main/kotlin/strikt/assertions/Iterable.kt
+++ b/strikt-core/src/main/kotlin/strikt/assertions/Iterable.kt
@@ -78,7 +78,7 @@ fun <T : Iterable<E>, E> Builder<T>.withElementAt(
 fun <T : Collection<E>, E> Builder<T>.single(): Builder<E> =
   assert("has only one element") {
     if (it.size == 1) pass(it.size)
-    else fail(it.size)
+    else fail(it)
   }
     .get("single element %s") { single() }
 

--- a/strikt-core/src/test/kotlin/strikt/Mapping.kt
+++ b/strikt-core/src/test/kotlin/strikt/Mapping.kt
@@ -60,7 +60,7 @@ internal class Mapping {
       expectThat(error).message.isEqualTo(
         """▼ Expect that []:
           |  ✗ has only one element
-          |    found 0"""
+          |    found []"""
           .trimMargin()
       )
     }
@@ -75,7 +75,7 @@ internal class Mapping {
       expectThat(error).message.isEqualTo(
         """▼ Expect that ["catflap", "rubberplant"]:
           |  ✗ has only one element
-          |    found 2"""
+          |    found ["catflap", "rubberplant"]"""
           .trimMargin()
       )
     }


### PR DESCRIPTION
if i expect one element and get two instead its very useful what those two were. and in a nested assert the value is not printed anywhere else in the error message.