### PR TITLE
Add propertiesAreEqualToIgnoring assertion

### DIFF
--- a/strikt-jvm/src/main/kotlin/strikt/java/Any.kt
+++ b/strikt-jvm/src/main/kotlin/strikt/java/Any.kt
@@ -4,6 +4,7 @@ import strikt.api.Assertion
 import strikt.assertions.contentEquals
 import strikt.assertions.isEqualTo
 import java.beans.Introspector
+import kotlin.reflect.KProperty1
 
 /**
  * Asserts that all properties of the subject match those of [other] according
@@ -13,11 +14,32 @@ import java.beans.Introspector
  * Properties are identified using Java beans conventions.
  */
 infix fun <T : Any> Assertion.Builder<T>.propertiesAreEqualTo(other: T): Assertion.Builder<T> =
+  compareFieldByField(other)
+
+/**
+ * Asserts that all properties of the subject except [ignoredProperties] match
+ * those of [other] according to either [contentEquals] in the case of array
+ * properties or [isEqualTo] in other cases.
+ *
+ * Properties are identified using Java beans conventions.
+ */
+fun <T : Any> Assertion.Builder<T>.propertiesAreEqualToIgnoring(
+  other: T,
+  vararg ignoredProperties: KProperty1<T, Any>
+): Assertion.Builder<T> = compareFieldByField(
+  other,
+  ignoredProperties.map(KProperty1<T, Any>::name)
+)
+
+private fun <T : Any> Assertion.Builder<T>.compareFieldByField(
+  other: T,
+  ignoredPropertyNames: List<String> = emptyList()
+): Assertion.Builder<T> =
   compose("is equal field-by-field to %s", other) { subject ->
     Introspector.getBeanInfo(subject.javaClass).let { beanInfo ->
       beanInfo
         .propertyDescriptors
-        .filter { it.name != "class" }
+        .filter { it.name != "class" && it.name !in ignoredPropertyNames }
         .forEach { property ->
           val mappedAssertion = get("value of property ${property.name}") {
             property.readMethod(this)

--- a/strikt-jvm/src/test/kotlin/strikt/java/BeanPropertyAssertions.kt
+++ b/strikt-jvm/src/test/kotlin/strikt/java/BeanPropertyAssertions.kt
@@ -78,7 +78,6 @@ internal object BeanPropertyAssertions {
       dateOfBirth = LocalDate.of(1947, 1, 8),
       image = "catflap".toByteArray()
     )
-
     val error = assertThrows<AssertionError> {
       expectThat(subject).propertiesAreEqualToIgnoring(
         other,

--- a/strikt-jvm/src/test/kotlin/strikt/java/BeanPropertyAssertions.kt
+++ b/strikt-jvm/src/test/kotlin/strikt/java/BeanPropertyAssertions.kt
@@ -67,6 +67,40 @@ internal object BeanPropertyAssertions {
   }
 
   @Test
+  fun `ignores excluded properties`() {
+    val subject = PersonKotlin(
+      name = "David",
+      dateOfBirth = LocalDate.of(1947, 1, 8),
+      image = "catflap".toByteArray()
+    )
+    val other = PersonKotlin(
+      name = "Ziggy",
+      dateOfBirth = LocalDate.of(1947, 1, 8),
+      image = "catflap".toByteArray()
+    )
+
+    val error = assertThrows<AssertionError> {
+      expectThat(subject).propertiesAreEqualToIgnoring(
+        other,
+        PersonKotlin::id,
+        PersonKotlin::image
+      )
+    }
+    expectThat(error.message) {
+      isNotNull()
+      isEqualTo(
+        """▼ Expect that Person(David):
+          |  ✗ is equal field-by-field to Person(Ziggy)
+          |    ▼ value of property dateOfBirth:
+          |      ✓ is equal to 1947-01-08
+          |    ▼ value of property name:
+          |      ✗ is equal to "Ziggy"
+          |              found "David"""".trimMargin()
+      )
+    }
+  }
+
+  @Test
   fun `isEqualTo works with java fields that are null`() {
     val subject = PersonJava(null, null, null, null)
     expectThat(


### PR DESCRIPTION
Closes https://github.com/robfletcher/strikt/issues/167.

This PR adds a new version of `Assertion.Builder<T>.propertiesAreEqualTo` that takes a list of ignored properties in the form of `KProperty`. When comparing property by property, the ignored properties will be skipped.

### Rationale
- The new functionality needs to go into a new function, as the existing one is an `infix` function and therefore can't have a second parameter
- The new parameter is of type `KProperty` as it's convenient and fits in with the rest of the strikt API. The downside is that getters/setters from Java can not be passed in as they are functions, which is an acceptable limitation in my opinion as the function is explicitly called **properties**AreEqualTo. In addition to that, the existing logic compares field names and not getters/setters, so that would be confusing anyway
- I did not pursue the idea mentioned in the issue of a more fancy syntax like `expectThat(subject).ignoring(...).propertiesAreEqualTo(...)` as I don't think the current assertion builder design allows for it and I don't think it would be appreciated if an external contribution changes fundamentals like that

### Usage example
```kotlin
data class SomeClass(id: String, name: String)

val subject = SomeClass("123", "Christian")
val other = SomeClass("123", "Rob")

// fails with existing propetiesAreEqualTo
expectThat(subject) propertiesAreEqualTo other

// passes with new propertiesAreEqualToIgnoring
expectThat(subject).propertiesAreEqualToIgnoring(other, SomeClass::name)
```

**Happy to discuss and adjust the name of the function or the implementation.**