### PR TITLE
Fix the assertion description for isAfter

### DIFF
--- a/strikt-jvm/src/main/kotlin/strikt/java/time/TemporalAccessor.kt
+++ b/strikt-jvm/src/main/kotlin/strikt/java/time/TemporalAccessor.kt
@@ -43,7 +43,7 @@ infix fun <T : TemporalAccessor> Assertion.Builder<T>.isBefore(expected: Tempora
  * temporal type.
  */
 infix fun <T : TemporalAccessor> Assertion.Builder<T>.isAfter(expected: TemporalAccessor): Assertion.Builder<T> =
-  assertThat("is before %s", expected) {
+  assertThat("is after %s", expected) {
     when (it) {
       is Instant -> it.isAfter(Instant.from(expected))
       is ChronoLocalDate -> it.isAfter(LocalDate.from(expected))

--- a/strikt-jvm/src/test/kotlin/strikt/java/time/TemporalAssertions.kt
+++ b/strikt-jvm/src/test/kotlin/strikt/java/time/TemporalAssertions.kt
@@ -181,7 +181,7 @@ internal class TemporalAssertions : JUnit5Minutests {
         local to local.minusDays(1),
         Pair(localOffset, localOffset.minusNanos(1))
       ).forEach { (subject, expected) ->
-        test("passes asserting $subject (${subject.javaClass.simpleName}) is before $expected (${expected.javaClass.simpleName})") {
+        test("passes asserting $subject (${subject.javaClass.simpleName}) is after $expected (${expected.javaClass.simpleName})") {
           expectThat(subject).isAfter(expected)
         }
       }
@@ -215,7 +215,7 @@ internal class TemporalAssertions : JUnit5Minutests {
         local to local.plusDays(1),
         Pair(localOffset, localOffset.plusNanos(1))
       ).forEach { (subject, expected) ->
-        test("fails asserting $subject (${subject.javaClass.simpleName}) is before $expected (${expected.javaClass.simpleName})") {
+        test("fails asserting $subject (${subject.javaClass.simpleName}) is after $expected (${expected.javaClass.simpleName})") {
           assertThrows<AssertionFailedError> {
             expectThat(subject).isAfter(expected)
           }


### PR DESCRIPTION
I noticed that the description for isAfter was the same as isBefore (incorrect). Here's the simple fix.

I noticed the descriptions aren't covered by the tests (only whether the assertions pass or fail) but I updated the tests as well anyway even if it's just cosmetic.