### PR TITLE
run ci also on windows. but only on jdk 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,20 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: Build on Java ${{ matrix.java }}
-    runs-on: ubuntu-latest
     strategy:
       matrix:
+        os: [ ubuntu-latest, windows-latest ]
         java: [8, 11, 17, 19]
+        exclude:
+          - os: windows-latest
+            java: 8
+          - os: windows-latest
+            java: 11
+          - os: windows-latest
+            java: 19
+
+    name: Build on Java ${{ matrix.java }} - ${{ matrix.os}}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
it's not necessary to run on all jdks because jdk compatibility is already tested by the linux builds. the windows build is mainly there for line ending and path separator problems.

Also I hope this works, because I have no way to test it locally. 