### PR TITLE
Prevent malicious Gradle wrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
       - name: Set up Java
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
This prevents anyone from submitting a malicious gradle wrapper.

For more details:
https://github.com/marketplace/actions/gradle-wrapper-validation