### PR TITLE
Use gradle-build-action to speedup builds on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,7 @@ jobs:
         with:
           distribution: zulu
           java-version: ${{ matrix.java }}
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       - name: Build with Gradle
         run: ./gradlew build


### PR DESCRIPTION
This is the recommended action for running Gradle in github workflows as it enables caching that speeds up CI builds.

For more details:
https://github.com/marketplace/actions/gradle-build-action