### PR TITLE
Fix runs-on github-workflow configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
           - os: windows-latest
             java: 19
 
-    name: Build on Java ${{ matrix.java }} - ${{ matrix.os}}
-    runs-on: ubuntu-latest
+    name: Build on Java ${{ matrix.java }} - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Resolves:
https://github.com/robfletcher/strikt/issues/282

Note that it should now start failing on Windows which is expected behavior as that's a secondary issue that needs to be addressed due to tests expecting `\n` line separators