### PR TITLE
Fix line separators

### DIFF
--- a/strikt-core/src/main/kotlin/strikt/internal/reporting/DefaultResultWriter.kt
+++ b/strikt-core/src/main/kotlin/strikt/internal/reporting/DefaultResultWriter.kt
@@ -89,7 +89,7 @@ internal open class DefaultResultWriter : ResultWriter {
     writer
       .append(
         description.format(formattedValue).lines().joinToString(
-          "\n${"".padStart(
+          "$EOL${"".padStart(
             valueIndent
           )}|"
         )
@@ -120,13 +120,13 @@ internal open class DefaultResultWriter : ResultWriter {
               val lines = it.lines()
               if (lines.size > 1) {
                 lines
-                  .joinToString("\n${"".padStart(descriptionIndentFollowing)}|")
+                  .joinToString("$EOL${"".padStart(descriptionIndentFollowing)}|")
               } else {
                 it
               }
             }
           )
-          .append("\n")
+          .append(EOL)
         writeLineStart(writer, this, indent)
         writer
           .append("".padEnd(alignIndent))
@@ -134,7 +134,7 @@ internal open class DefaultResultWriter : ResultWriter {
             failedDescription.format(formattedComparison.actual).let {
               val lines = it.lines()
               if (lines.size > 1) {
-                lines.joinToString("\n${"".padStart(alignIndentFollowing)}|")
+                lines.joinToString("$EOL${"".padStart(alignIndentFollowing)}|")
               } else {
                 it
               }

--- a/strikt-core/src/main/kotlin/strikt/internal/reporting/ResultWriter.kt
+++ b/strikt-core/src/main/kotlin/strikt/internal/reporting/ResultWriter.kt
@@ -8,7 +8,7 @@ internal interface ResultWriter {
 
   fun writeTo(writer: Appendable, results: Iterable<AssertionNode<*>>) =
     results.forEachIndexed { index, it ->
-      if (index > 0) writer.append("\n")
+      if (index > 0) writer.append(System.lineSeparator())
       writeTo(writer, it)
     }
 

--- a/strikt-core/src/test/kotlin/strikt/Block.kt
+++ b/strikt-core/src/test/kotlin/strikt/Block.kt
@@ -43,7 +43,7 @@ internal class Block {
         |  ✓ is an instance of java.lang.String
         |  ✗ is an instance of java.lang.Number
         |                found java.lang.String"""
-          .trimMargin()
+          .trimMargin().replace("\n", System.lineSeparator())
       expectThat(error.message).isEqualTo(expected)
     }
   }
@@ -66,7 +66,7 @@ internal class Block {
         |  ✗ is an instance of java.lang.Number
         |                found java.lang.String
         |  ✓ is equal to "fnord""""
-          .trimMargin()
+          .trimMargin().replace("\n", System.lineSeparator())
       expectThat(error.message).isEqualTo(expected)
     }
   }
@@ -83,7 +83,7 @@ internal class Block {
         """
         |▼ Expect that null:
         |  ✗ is not null"""
-          .trimMargin()
+          .trimMargin().replace("\n", System.lineSeparator())
       expectThat(error.message).isEqualTo(expected)
     }
   }
@@ -102,7 +102,7 @@ internal class Block {
         |▼ Expect that "fnord":
         |  ✗ is an instance of java.lang.Integer
         |                found java.lang.String"""
-          .trimMargin()
+          .trimMargin().replace("\n", System.lineSeparator())
       expectThat(error.message).isEqualTo(expected)
     }
   }
@@ -127,7 +127,7 @@ internal class Block {
         |  ✗ is not an instance of java.lang.String (Class)
         |                    found java.lang.String (Class)
         |  ✓ is not an instance of java.lang.Number"""
-          .trimMargin()
+          .trimMargin().replace("\n", System.lineSeparator())
       expectThat(error.message).isEqualTo(expected)
     }
   }
@@ -152,7 +152,7 @@ internal class Block {
         |  ✗ is not an instance of java.lang.String (Class)
         |                    found java.lang.String (Class)
         |  ✓ is not an instance of java.lang.Number"""
-          .trimMargin()
+          .trimMargin().replace("\n", System.lineSeparator())
       expectThat(error.message).isEqualTo(expected)
     }
   }
@@ -191,7 +191,7 @@ internal class Block {
         |    ✗ ends with "y"
         |          found "d"
         |    ✓ has length 5"""
-          .trimMargin()
+          .trimMargin().replace("\n", System.lineSeparator())
       expectThat(error.message).isEqualTo(expected)
     }
   }
@@ -216,7 +216,7 @@ internal class Block {
         |    ✗ ends with "y"
         |          found "d"
         |    ✓ has length 5"""
-          .trimMargin()
+          .trimMargin().replace("\n", System.lineSeparator())
       expectThat(error.message).isEqualTo(expected)
     }
   }
@@ -246,7 +246,7 @@ internal class Block {
         |    ✗ ends with "y"
         |          found "d"
         |    ✓ has length 5"""
-          .trimMargin()
+          .trimMargin().replace("\n", System.lineSeparator())
       expectThat(error.message).isEqualTo(expected)
     }
   }
@@ -274,7 +274,7 @@ internal class Block {
         |    ✗ ends with "y"
         |          found "d"
         |    ✓ has length 5"""
-          .trimMargin()
+          .trimMargin().replace("\n", System.lineSeparator())
       expectThat(error.message).isEqualTo(expected)
     }
   }

--- a/strikt-core/src/test/kotlin/strikt/Catching.kt
+++ b/strikt-core/src/test/kotlin/strikt/Catching.kt
@@ -43,7 +43,7 @@ internal class Catching : JUnit5Minutests {
             |▼ Expect that Success(kthxbye):
             |  ✗ is failure
             |    returned "kthxbye"
-          """.trimMargin()
+          """.trimMargin().replace("\n", System.lineSeparator())
           )
         }
       }
@@ -78,7 +78,7 @@ internal class Catching : JUnit5Minutests {
             |▼ Expect that Failure(java.lang.IllegalStateException: o noes):
             |  ✗ is success
             |    threw java.lang.IllegalStateException
-          """.trimMargin()
+          """.trimMargin().replace("\n", System.lineSeparator())
           )
         }
       }

--- a/strikt-core/src/test/kotlin/strikt/Chained.kt
+++ b/strikt-core/src/test/kotlin/strikt/Chained.kt
@@ -47,8 +47,9 @@ internal class Chained {
       expectThat(subject).not().isLowerCase()
     }
     expectThat(error.message).isEqualTo(
-      "▼ Expect that \"fnord\":\n" +
-        "  ✗ is not lower case"
+      """▼ Expect that "fnord":
+      |  ✗ is not lower case"""
+        .trimMargin().replace("\n", System.lineSeparator())
     )
   }
 
@@ -65,7 +66,8 @@ internal class Chained {
         |    ✓ contains 2
         |    ✓ …at index 1
         |    ✗ contains no further elements
-        |      found [3, 4]""".trimMargin()
+        |      found [3, 4]"""
+        .trimMargin().replace("\n", System.lineSeparator())
     expectThat(error)
       .isA<AssertionFailedError>()
       .message
@@ -93,7 +95,7 @@ internal class Chained {
         |  ✓ contains "n"
         |  ✗ contains "z"
         |       found "fnord""""
-        .trimMargin()
+        .trimMargin().replace("\n", System.lineSeparator())
     )
   }
 

--- a/strikt-core/src/test/kotlin/strikt/Composition.kt
+++ b/strikt-core/src/test/kotlin/strikt/Composition.kt
@@ -20,9 +20,10 @@ internal class Composition {
         if (allPassed) pass() else fail()
       }
     }.let { error ->
-      val expected = "▼ Expect that \"fnord\":\n" +
-        "  ✗ matches a negated assertion\n" +
-        "    ✗ is not lower case"
+      val expected = """▼ Expect that "fnord":
+                            |  ✗ matches a negated assertion
+                            |    ✗ is not lower case"""
+                              .trimMargin().replace("\n", System.lineSeparator())
       expectThat(error.message).isEqualTo(expected)
     }
   }

--- a/strikt-core/src/test/kotlin/strikt/Exceptions.kt
+++ b/strikt-core/src/test/kotlin/strikt/Exceptions.kt
@@ -35,7 +35,7 @@ class Exceptions {
           """▼ Expect that "fnord":
             |  ✓ has length 5
             |  ✗ is upper case"""
-            .trimMargin()
+            .trimMargin().replace("\n", System.lineSeparator())
         )
     }
   }
@@ -57,7 +57,7 @@ class Exceptions {
               |  ✓ has length 5
               |  ✗ is upper case
               |  ✓ starts with "f""""
-              .trimMargin()
+              .trimMargin().replace("\n", System.lineSeparator())
           )
           get { failures }
             .hasSize(1)
@@ -66,7 +66,7 @@ class Exceptions {
             .message.isEqualTo(
               """▼ Expect that "fnord":
                 |  ✗ is upper case"""
-                .trimMargin()
+                .trimMargin().replace("\n", System.lineSeparator())
             )
         }
     }
@@ -95,7 +95,7 @@ class Exceptions {
               |            found 5
               |    ✗ is less than 2
               |    ✗ is not equal to 5"""
-              .trimMargin()
+              .trimMargin().replace("\n", System.lineSeparator())
           )
         }
         .get { failures }
@@ -109,7 +109,7 @@ class Exceptions {
                 |  ▼ value of property length:
                 |    ✗ is equal to 1
                 |            found 5"""
-                .trimMargin()
+                .trimMargin().replace("\n", System.lineSeparator())
             )
         }
         .and {
@@ -120,7 +120,7 @@ class Exceptions {
               """▼ Expect that "fnord":
                 |  ▼ value of property length:
                 |    ✗ is less than 2"""
-                .trimMargin()
+                .trimMargin().replace("\n", System.lineSeparator())
             )
         }
         .and {
@@ -131,7 +131,7 @@ class Exceptions {
               """▼ Expect that "fnord":
                 |  ▼ value of property length:
                 |    ✗ is not equal to 5"""
-                .trimMargin()
+                .trimMargin().replace("\n", System.lineSeparator())
             )
         }
     }
@@ -161,7 +161,7 @@ class Exceptions {
               |            found 5
               |    ✗ is less than 2
               |    ✗ is not equal to 5"""
-              .trimMargin()
+              .trimMargin().replace("\n", System.lineSeparator())
           )
         }
         .get { failures }
@@ -177,7 +177,7 @@ class Exceptions {
             |            found 5
             |    ✗ is less than 2
             |    ✗ is not equal to 5"""
-            .trimMargin()
+            .trimMargin().replace("\n", System.lineSeparator())
         )
     }
   }
@@ -201,7 +201,7 @@ class Exceptions {
               |    ✓ …at index 1
               |    ✗ contains no further elements
               |      found ["marzipan"]"""
-              .trimMargin()
+              .trimMargin().replace("\n", System.lineSeparator())
           )
       }
   }
@@ -227,7 +227,7 @@ class Exceptions {
                 """▼ Expect that ["catflap", "rubberplant", "marzipan"]:
                   |  ✗ has size 2
                   |       found 3"""
-                  .trimMargin()
+                  .trimMargin().replace("\n", System.lineSeparator())
               )
             get(1)
               .isA<AssertionFailedError>()
@@ -241,7 +241,7 @@ class Exceptions {
                   |    ✓ …at index 1
                   |    ✗ contains no further elements
                   |      found ["marzipan"]"""
-                  .trimMargin()
+                  .trimMargin().replace("\n", System.lineSeparator())
               )
           }
       }

--- a/strikt-core/src/test/kotlin/strikt/Formatting.kt
+++ b/strikt-core/src/test/kotlin/strikt/Formatting.kt
@@ -36,7 +36,8 @@ internal class Formatting {
         |    ▼ "rubberplant":
         |      ✗ is upper case
         |    ▼ "marzipan":
-        |      ✗ is upper case""".trimMargin()
+        |      ✗ is upper case"""
+        .trimMargin().replace("\n", System.lineSeparator())
     expectThat(error.message).isEqualTo(expected)
   }
 
@@ -68,7 +69,8 @@ internal class Formatting {
         |    ▼ "marzipan":
         |      ✗ is upper case
         |      ✗ starts with 'c'
-        |              found 'm'""".trimMargin()
+        |              found 'm'"""
+        .trimMargin().replace("\n", System.lineSeparator())
     expectThat(error.message).isEqualTo(expected)
   }
 
@@ -95,7 +97,8 @@ internal class Formatting {
         |              found 'r'
         |    ▼ "marzipan":
         |      ✗ starts with 'c'
-        |              found 'm'""".trimMargin()
+        |              found 'm'"""
+        .trimMargin().replace("\n", System.lineSeparator())
 
     expectThat(error.message).isEqualTo(expected)
   }
@@ -143,12 +146,14 @@ internal class Formatting {
     val subject =
       """a string
                |with
-               |line breaks""".trimMargin()
+               |line breaks"""
+        .trimMargin().replace("\n", System.lineSeparator())
 
     val e = assertThrows<AssertionError> {
       expectThat(subject) isEqualTo """a different string
                                       |with
-                                      |line breaks""".trimMargin()
+                                      |line breaks"""
+        .trimMargin().replace("\n", System.lineSeparator())
     }
 
     expectThat(e.message).isEqualTo(
@@ -160,7 +165,8 @@ internal class Formatting {
         |                |line breaks"
         |          found "a string
         |                |with
-        |                |line breaks"""".trimMargin()
+        |                |line breaks""""
+        .trimMargin().replace("\n", System.lineSeparator())
     )
   }
 }

--- a/strikt-core/src/test/kotlin/strikt/Mapping.kt
+++ b/strikt-core/src/test/kotlin/strikt/Mapping.kt
@@ -61,7 +61,7 @@ internal class Mapping {
         """▼ Expect that []:
           |  ✗ has only one element
           |    found []"""
-          .trimMargin()
+          .trimMargin().replace("\n", System.lineSeparator())
       )
     }
   }
@@ -76,7 +76,7 @@ internal class Mapping {
         """▼ Expect that ["catflap", "rubberplant"]:
           |  ✗ has only one element
           |    found ["catflap", "rubberplant"]"""
-          .trimMargin()
+          .trimMargin().replace("\n", System.lineSeparator())
       )
     }
   }
@@ -215,7 +215,8 @@ internal class Mapping {
           |            found "David"
           |  ▼ birth year:
           |    ✗ is equal to 1971
-          |            found 1947""".trimMargin()
+          |            found 1947"""
+          .trimMargin().replace("\n", System.lineSeparator())
       )
     }
 
@@ -228,7 +229,8 @@ internal class Mapping {
         """▼ Expect that Person(name=David, birthDate=1947-01-08):
           |  ▼ value of property name:
           |    ✗ is equal to "Ziggy"
-          |            found "David"""".trimMargin()
+          |            found "David""""
+          .trimMargin().replace("\n", System.lineSeparator())
       )
     }
 
@@ -247,7 +249,8 @@ internal class Mapping {
           |            found "David"
           |  ▼ birthDate.year:
           |    ✗ is equal to 1971
-          |            found 1947""".trimMargin()
+          |            found 1947"""
+          .trimMargin().replace("\n", System.lineSeparator())
       )
     }
 
@@ -263,7 +266,8 @@ internal class Mapping {
           |  ▼ value of property birthDate:
           |    ▼ return value of getYear:
           |      ✗ is equal to 1971
-          |              found 1947""".trimMargin()
+          |              found 1947"""
+          .trimMargin().replace("\n", System.lineSeparator())
       )
     }
   }

--- a/strikt-core/src/test/kotlin/strikt/Nested.kt
+++ b/strikt-core/src/test/kotlin/strikt/Nested.kt
@@ -24,12 +24,13 @@ internal class Nested {
         that("FNØRD").isLowerCase()
       }
     }.let { error ->
-      val expected = "▼ Expect that \"fnord\":\n" +
-        "  ✗ is null\n" +
-        "▼ Expect that \"FNORD\":\n" +
-        "  ✓ is upper case\n" +
-        "▼ Expect that \"FNØRD\":\n" +
-        "  ✗ is lower case"
+      val expected = """▼ Expect that "fnord":
+                           |  ✗ is null
+                           |▼ Expect that "FNORD":
+                           |  ✓ is upper case
+                           |▼ Expect that "FNØRD":
+                           |  ✗ is lower case"""
+                            .trimMargin().replace("\n", System.lineSeparator())
       expectThat(expected).isEqualTo(error.message)
     }
   }
@@ -49,7 +50,8 @@ internal class Nested {
                           |          found "foo"
                           |▼ Expect that pass 2:
                           |  ✗ is equal to "bar"
-                          |          found "foo"""".trimMargin()
+                          |          found "foo""""
+      .trimMargin().replace("\n", System.lineSeparator())
   }
 
   @Test
@@ -68,12 +70,13 @@ internal class Nested {
         that(delayedReturnValue("FNØRD")).isLowerCase()
       }
     }.let { error ->
-      val expected = "▼ Expect that \"fnord\":\n" +
-        "  ✗ is null\n" +
-        "▼ Expect that \"FNORD\":\n" +
-        "  ✓ is upper case\n" +
-        "▼ Expect that \"FNØRD\":\n" +
-        "  ✗ is lower case"
+      val expected = """▼ Expect that "fnord":
+                             |  ✗ is null
+                             |▼ Expect that "FNORD":
+                             |  ✓ is upper case
+                             |▼ Expect that "FNØRD":
+                             |  ✗ is lower case"""
+                              .trimMargin().replace("\n", System.lineSeparator())
       expectThat(expected).isEqualTo(error.message)
     }
   }

--- a/strikt-core/src/test/kotlin/strikt/Throws.kt
+++ b/strikt-core/src/test/kotlin/strikt/Throws.kt
@@ -31,7 +31,7 @@ internal class Throws {
         """▼ Expect that Success(kotlin.Unit):
           |  ✗ is failure
           |    returned kotlin.Unit"""
-          .trimMargin()
+          .trimMargin().replace("\n", System.lineSeparator())
       expectThat(error.message).isEqualTo(expected)
     }
   }
@@ -47,7 +47,7 @@ internal class Throws {
           |  ▼ exception:
           |    ✗ is an instance of java.lang.NullPointerException
           |                  found java.lang.IllegalStateException"""
-          .trimMargin()
+          .trimMargin().replace("\n", System.lineSeparator())
       expectThat(error.message).isEqualTo(expected)
     }
   }

--- a/strikt-core/src/test/kotlin/strikt/assertions/AnyAssertions.kt
+++ b/strikt-core/src/test/kotlin/strikt/assertions/AnyAssertions.kt
@@ -189,7 +189,8 @@ internal object AnyAssertions : JUnit5Minutests {
           expectThat(error.message).isEqualTo(
             """▼ Expect that 5:
             |  ✗ is equal to 5 (Int)
-            |          found 5 (Long)""".trimMargin()
+            |          found 5 (Long)"""
+              .trimMargin().replace("\n", System.lineSeparator())
           )
         }
       }

--- a/strikt-core/src/test/kotlin/strikt/assertions/ArrayAssertions.kt
+++ b/strikt-core/src/test/kotlin/strikt/assertions/ArrayAssertions.kt
@@ -33,7 +33,7 @@ internal object ArrayAssertions {
           expectThat(error.message).isEqualTo(
             """▼ Expect that 0x${subject.toHex()}:
                 |  ✗ array content equals 0x${expected.toHex()}"""
-              .trimMargin()
+              .trimMargin().replace("\n", System.lineSeparator())
           )
         }
 
@@ -45,7 +45,7 @@ internal object ArrayAssertions {
           expectThat(error.message).isEqualTo(
             """▼ Expect that 0x${subject.toHex()}:
                 |  ✗ array content equals 0x${expected.toHex()}"""
-              .trimMargin()
+              .trimMargin().replace("\n", System.lineSeparator())
           )
         }
       }
@@ -64,7 +64,7 @@ internal object ArrayAssertions {
             """▼ Expect that 0x${subject.toHex()}:
                 |  ✗ is equal to 0x${expected.toHex()}
                 |          found 0x${subject.toHex()}"""
-              .trimMargin()
+              .trimMargin().replace("\n", System.lineSeparator())
           )
         }
 
@@ -117,7 +117,7 @@ internal object ArrayAssertions {
                 |  ✗ array content equals ${expected
               .toList()
               .map { "'$it'" }}"""
-              .trimMargin()
+              .trimMargin().replace("\n", System.lineSeparator())
           )
         }
 
@@ -129,7 +129,7 @@ internal object ArrayAssertions {
           expectThat(error.message).isEqualTo(
             """▼ Expect that ${subject.toList().map { "'$it'" }}:
               |  ✗ array content equals ${expected.toList().map { "'$it'" }}"""
-              .trimMargin()
+              .trimMargin().replace("\n", System.lineSeparator())
           )
         }
       }
@@ -148,7 +148,7 @@ internal object ArrayAssertions {
             """▼ Expect that ${subject.toList().map { "'$it'" }}:
                 |  ✗ is equal to ${expected.toList().map { "'$it'" }}
                 |          found ${subject.toList().map { "'$it'" }}"""
-              .trimMargin()
+              .trimMargin().replace("\n", System.lineSeparator())
           )
         }
 

--- a/strikt-core/src/test/kotlin/strikt/assertions/IterableAssertions.kt
+++ b/strikt-core/src/test/kotlin/strikt/assertions/IterableAssertions.kt
@@ -442,7 +442,8 @@ internal object IterableAssertions : JUnit5Minutests {
           |  ✗ contains the elements ["fnord", "marzipan", "bojack"]
           |    ✗ contains "fnord"
           |    ✓ contains "marzipan"
-          |    ✗ contains "bojack"""".trimMargin()
+          |    ✗ contains "bojack""""
+            .trimMargin().replace("\n", System.lineSeparator())
         )
       }
 
@@ -452,8 +453,9 @@ internal object IterableAssertions : JUnit5Minutests {
             .contains("fnord")
         }
         expectThat(error.message).isEqualTo(
-          "▼ Expect that [\"catflap\", \"rubberplant\", \"marzipan\"]:\n" +
-            "  ✗ contains \"fnord\""
+          """▼ Expect that ["catflap", "rubberplant", "marzipan"]:
+            |  ✗ contains "fnord""""
+            .trimMargin().replace("\n", System.lineSeparator())
         )
       }
     }
@@ -532,7 +534,8 @@ internal object IterableAssertions : JUnit5Minutests {
           |  ✗ does not contain any of the elements ["catflap", "wye", "marzipan"]
           |    ✗ does not contain "catflap"
           |    ✓ does not contain "wye"
-          |    ✗ does not contain "marzipan"""".trimMargin()
+          |    ✗ does not contain "marzipan""""
+            .trimMargin().replace("\n", System.lineSeparator())
         )
       }
 
@@ -542,8 +545,9 @@ internal object IterableAssertions : JUnit5Minutests {
             .doesNotContain("catflap")
         }
         expectThat(error.message).isEqualTo(
-          "▼ Expect that [\"catflap\", \"rubberplant\", \"marzipan\"]:\n" +
-            "  ✗ does not contain \"catflap\""
+          """▼ Expect that ["catflap", "rubberplant", "marzipan"]:
+            |  ✗ does not contain "catflap""""
+            .trimMargin().replace("\n", System.lineSeparator())
         )
       }
     }
@@ -597,7 +601,8 @@ internal object IterableAssertions : JUnit5Minutests {
             |    ✓ contains "rubberplant"
             |    ✓ …at index 1
             |    ✗ contains no further elements
-            |      found ["marzipan"]""".trimMargin()
+            |      found ["marzipan"]"""
+              .trimMargin().replace("\n", System.lineSeparator())
           )
         }
 
@@ -616,7 +621,8 @@ internal object IterableAssertions : JUnit5Minutests {
             |    ✓ contains "marzipan"
             |    ✓ …at index 2
             |    ✗ contains "fnord"
-            |    ✓ contains no further elements""".trimMargin()
+            |    ✓ contains no further elements"""
+              .trimMargin().replace("\n", System.lineSeparator())
           )
         }
 
@@ -646,7 +652,8 @@ internal object IterableAssertions : JUnit5Minutests {
             |      found "rubberplant"
             |    ✓ contains "marzipan"
             |    ✓ …at index 2
-            |    ✓ contains no further elements""".trimMargin()
+            |    ✓ contains no further elements"""
+              .trimMargin().replace("\n", System.lineSeparator())
           )
         }
 
@@ -665,7 +672,8 @@ internal object IterableAssertions : JUnit5Minutests {
             |    ✓ contains "marzipan"
             |    ✓ …at index 2
             |    ✗ contains "marzipan"
-            |    ✓ contains no further elements""".trimMargin()
+            |    ✓ contains no further elements"""
+              .trimMargin().replace("\n", System.lineSeparator())
           )
         }
       }
@@ -781,7 +789,8 @@ internal object IterableAssertions : JUnit5Minutests {
             |    ✓ contains "catflap"
             |    ✓ contains "rubberplant"
             |    ✗ contains no further elements
-            |      found ["marzipan"]""".trimMargin()
+            |      found ["marzipan"]"""
+              .trimMargin().replace("\n", System.lineSeparator())
           )
         }
 
@@ -802,7 +811,8 @@ internal object IterableAssertions : JUnit5Minutests {
             |    ✓ contains "rubberplant"
             |    ✓ contains "marzipan"
             |    ✗ contains "marzipan"
-            |    ✓ contains no further elements""".trimMargin()
+            |    ✓ contains no further elements"""
+              .trimMargin().replace("\n", System.lineSeparator())
           )
         }
 
@@ -823,7 +833,8 @@ internal object IterableAssertions : JUnit5Minutests {
             |    ✓ contains "rubberplant"
             |    ✓ contains "marzipan"
             |    ✗ contains "fnord"
-            |    ✓ contains no further elements""".trimMargin()
+            |    ✓ contains no further elements"""
+              .trimMargin().replace("\n", System.lineSeparator())
           )
         }
 

--- a/strikt-core/src/test/kotlin/strikt/assertions/ListAssertions.kt
+++ b/strikt-core/src/test/kotlin/strikt/assertions/ListAssertions.kt
@@ -32,7 +32,8 @@ internal object ListAssertions : JUnit5Minutests {
             }
             expectThat(exception.message).isEqualTo(
               """▼ Expect that [1, 2, 3, 4]:
-            |  ✗ contains the sequence: [1, 4] in exactly the same order""".trimMargin()
+            |  ✗ contains the sequence: [1, 4] in exactly the same order"""
+                  .trimMargin().replace("\n", System.lineSeparator())
             )
           }
 
@@ -43,7 +44,8 @@ internal object ListAssertions : JUnit5Minutests {
             }
             expectThat(exception.message).isEqualTo(
               """▼ Expect that [1, 2, 3, 4]:
-              |  ✗ contains the sequence: [1, 2, 3, 4, 5] in exactly the same order : expected sequence cannot be longer than subject""".trimMargin()
+              |  ✗ contains the sequence: [1, 2, 3, 4, 5] in exactly the same order : expected sequence cannot be longer than subject"""
+                  .trimMargin().replace("\n", System.lineSeparator())
             )
           }
 
@@ -54,7 +56,8 @@ internal object ListAssertions : JUnit5Minutests {
             }
             expectThat(exception.message).isEqualTo(
               """▼ Expect that [1, 2, 3, 4]:
-            |  ✗ contains the sequence: [] in exactly the same order : expected sequence cannot empty""".trimMargin()
+            |  ✗ contains the sequence: [] in exactly the same order : expected sequence cannot empty"""
+                  .trimMargin().replace("\n", System.lineSeparator())
             )
           }
         }

--- a/strikt-core/src/test/kotlin/strikt/assertions/MapAssertions.kt
+++ b/strikt-core/src/test/kotlin/strikt/assertions/MapAssertions.kt
@@ -78,7 +78,7 @@ internal object MapAssertions : JUnit5Minutests {
           expectThat(error.message).isEqualTo(
             """▼ Expect that {"foo"="bar", "baz"="fnord", "qux"="fnord"}:
               |  ✗ has an entry with the key "bar""""
-              .trimMargin()
+              .trimMargin().replace("\n", System.lineSeparator())
           )
         }
       }
@@ -95,7 +95,7 @@ internal object MapAssertions : JUnit5Minutests {
           expectThat(error.message).isEqualTo(
             """▼ Expect that {"foo"="bar", "baz"="fnord", "qux"="fnord"}:
               |  ✗ does not have an entry with the key "foo""""
-              .trimMargin()
+              .trimMargin().replace("\n", System.lineSeparator())
           )
         }
       }
@@ -115,7 +115,7 @@ internal object MapAssertions : JUnit5Minutests {
               |    ✓ has an entry with the key "foo"
               |    ✗ has an entry with the key "bar"
               |    ✗ has an entry with the key "fnord""""
-              .trimMargin()
+              .trimMargin().replace("\n", System.lineSeparator())
           )
         }
       }
@@ -135,7 +135,7 @@ internal object MapAssertions : JUnit5Minutests {
               |    ✓ does not have an entry with the key "bar"
               |    ✓ does not have an entry with the key "fnord"
               |    ✗ does not have an entry with the key "foo""""
-              .trimMargin()
+              .trimMargin().replace("\n", System.lineSeparator())
           )
         }
       }
@@ -152,7 +152,7 @@ internal object MapAssertions : JUnit5Minutests {
           expectThat(error.message).isEqualTo(
             """▼ Expect that {"foo"="bar", "baz"="fnord", "qux"="fnord"}:
               |  ✗ has an entry with the key "bar""""
-              .trimMargin()
+              .trimMargin().replace("\n", System.lineSeparator())
           )
         }
 
@@ -166,7 +166,7 @@ internal object MapAssertions : JUnit5Minutests {
               |  ▼ entry ["foo"]:
               |    ✗ is equal to "baz"
               |            found "bar""""
-              .trimMargin()
+              .trimMargin().replace("\n", System.lineSeparator())
           )
         }
       }
@@ -195,7 +195,7 @@ internal object MapAssertions : JUnit5Minutests {
                 """
                 |▼ Expect that {"foo"="bar", "baz"="fnord", "qux"="fnord"}:
                 |  ✗ has an entry with the key "bar"
-              """.trimMargin()
+              """.trimMargin().replace("\n", System.lineSeparator())
               )
           }
         }

--- a/strikt-core/src/test/kotlin/strikt/assertions/StringAssertions.kt
+++ b/strikt-core/src/test/kotlin/strikt/assertions/StringAssertions.kt
@@ -52,7 +52,8 @@ internal object StringAssertions : JUnit5Minutests {
           .contains(
             """▼ Expect that "fnord":
                     |  ✗ starts with "fnrd"
-                    |          found "fnor"""".trimMargin()
+                    |          found "fnor""""
+              .trimMargin().replace("\n", System.lineSeparator())
           )
       }
     }
@@ -73,7 +74,8 @@ internal object StringAssertions : JUnit5Minutests {
           .isEqualTo(
             """▼ Expect that "fnord":
                      |  ✗ ends with "nor"
-                     |        found "ord"""".trimMargin()
+                     |        found "ord""""
+              .trimMargin().replace("\n", System.lineSeparator())
           )
       }
     }

--- a/strikt-core/src/test/kotlin/strikt/docs/Assertions.kt
+++ b/strikt-core/src/test/kotlin/strikt/docs/Assertions.kt
@@ -48,7 +48,7 @@ internal class Assertions {
       // END assertion_styles_1
     }
       .message
-      .isEqualTo(s.removeSnippetTags().trimIndent().trim())
+      .isEqualTo(s.removeSnippetTags().trimIndent().replace("\n", System.lineSeparator()).trim())
   }
 
   @Test fun `assertion styles 3, 4`() {
@@ -74,7 +74,7 @@ internal class Assertions {
       // END assertion_styles_3
     }
       .message
-      .isEqualTo(s.removeSnippetTags().trimIndent().trim())
+      .isEqualTo(s.removeSnippetTags().trimIndent().replace("\n", System.lineSeparator()).trim())
   }
 
   @Test fun `assertion styles 5, 6`() {
@@ -97,7 +97,7 @@ internal class Assertions {
       // END assertion_styles_5
     }
       .message
-      .isEqualTo(s.removeSnippetTags().trimIndent().trim())
+      .isEqualTo(s.removeSnippetTags().trimIndent().replace("\n", System.lineSeparator()).trim())
   }
 
   @Test fun `assertion styles 7, 8`() {
@@ -129,7 +129,7 @@ internal class Assertions {
       // END assertion_styles_7
     }
       .message
-      .isEqualTo(s.removeSnippetTags().trimIndent().trim())
+      .isEqualTo(s.removeSnippetTags().trimIndent().replace("\n", System.lineSeparator()).trim())
   }
 
 // collection-elements.md
@@ -165,7 +165,7 @@ internal class Assertions {
       // END collections_2
     }
       .message
-      .isEqualTo(s.removeSnippetTags().trimIndent().trim())
+      .isEqualTo(s.removeSnippetTags().trimIndent().replace("\n", System.lineSeparator()).trim())
   }
 
 // expecting-exceptions.md

--- a/strikt-core/src/test/kotlin/strikt/docs/Chaining.kt
+++ b/strikt-core/src/test/kotlin/strikt/docs/Chaining.kt
@@ -67,7 +67,7 @@ internal class Chaining {
       // END traversing_subjects_2
     }
       .message
-      .isEqualTo(s.removeSnippetTags().trimIndent().trim())
+      .isEqualTo(s.removeSnippetTags().trimIndent().replace("\n", System.lineSeparator()).trim())
   }
 
   @Test fun `traversing subjects 4`() {

--- a/strikt-core/src/test/kotlin/strikt/docs/CustomAssertions.kt
+++ b/strikt-core/src/test/kotlin/strikt/docs/CustomAssertions.kt
@@ -41,7 +41,7 @@ internal class CustomAssertions {
       expectThat(LocalDate.of(2018, 5, 1)).isStTibsDay()
     }
       .message
-      .isEqualTo(s.removeSnippetTags().trimIndent().trim())
+      .isEqualTo(s.removeSnippetTags().trimIndent().replace("\n", System.lineSeparator()).trim())
   }
 
   @Test fun `custom assertions 3, 4`() {
@@ -71,7 +71,7 @@ internal class CustomAssertions {
       expectThat(LocalDate.of(2018, 5, 1)).isStTibsDay()
     }
       .message
-      .isEqualTo(s.removeSnippetTags().trimIndent().trim())
+      .isEqualTo(s.removeSnippetTags().trimIndent().replace("\n", System.lineSeparator()).trim())
   }
 
   @Test fun `custom assertions 5`() {
@@ -92,7 +92,7 @@ internal class CustomAssertions {
       expectThat(LocalDate.of(2018, 5, 1)).isStTibsDay()
     }
       .message
-      .isEqualTo(s.trimIndent().trim())
+      .isEqualTo(s.trimIndent().replace("\n", System.lineSeparator()).trim())
   }
 
   @Test fun `custom assertions 6`() {
@@ -129,6 +129,6 @@ internal class CustomAssertions {
       expectThat(subject).containsNoNullElements()
     }
       .message
-      .isEqualTo(s.removeSnippetTags().trimIndent().trim())
+      .isEqualTo(s.removeSnippetTags().trimIndent().replace("\n", System.lineSeparator()).trim())
   }
 }

--- a/strikt-core/src/test/kotlin/strikt/docs/Homepage.kt
+++ b/strikt-core/src/test/kotlin/strikt/docs/Homepage.kt
@@ -90,7 +90,7 @@ internal class Homepage {
       /* ktlint-enable no-multi-spaces */
     }
       .message
-      .isEqualTo(s.removeSnippetTags().trimIndent().trim())
+      .isEqualTo(s.removeSnippetTags().trimIndent().replace("\n", System.lineSeparator()).trim())
   }
 
   @Test

--- a/strikt-core/src/test/kotlin/strikt/internal/NegatedPhraseTest.kt
+++ b/strikt-core/src/test/kotlin/strikt/internal/NegatedPhraseTest.kt
@@ -28,7 +28,7 @@ internal class NegatedPhraseTest {
             expectThat("fnord").not().assert(phrase, "foo") { pass() }
           }
             .message
-            .isEqualTo("▼ Expect that \"fnord\":\n  ✗ $expected")
+            .isEqualTo("▼ Expect that \"fnord\":${System.lineSeparator()}  ✗ $expected")
         }
       }
 }

--- a/strikt-jvm/src/test/kotlin/strikt/java/BeanPropertyAssertions.kt
+++ b/strikt-jvm/src/test/kotlin/strikt/java/BeanPropertyAssertions.kt
@@ -61,7 +61,8 @@ internal object BeanPropertyAssertions {
           |      ✓ array content equals 0x636174666C6170
           |    ▼ value of property name:
           |      ✗ is equal to "Ziggy"
-          |              found "David"""".trimMargin()
+          |              found "David""""
+          .trimMargin().replace("\n", System.lineSeparator())
       )
     }
   }
@@ -94,7 +95,8 @@ internal object BeanPropertyAssertions {
           |      ✓ is equal to 1947-01-08
           |    ▼ value of property name:
           |      ✗ is equal to "Ziggy"
-          |              found "David"""".trimMargin()
+          |              found "David""""
+          .trimMargin().replace("\n", System.lineSeparator())
       )
     }
   }
@@ -142,7 +144,8 @@ internal object BeanPropertyAssertions {
           |      ✓ array content equals 0x636174666C6170
           |    ▼ value of property name:
           |      ✗ is equal to "Ziggy"
-          |              found "David"""".trimMargin()
+          |              found "David""""
+          .trimMargin().replace("\n", System.lineSeparator())
       )
     }
   }
@@ -182,7 +185,8 @@ internal object BeanPropertyAssertions {
             |              found "Oreo"
             |    ▼ value of property tails:
             |      ✗ is equal to 1
-            |              found 0""".trimMargin()
+            |              found 0"""
+            .trimMargin().replace("\n", System.lineSeparator())
         )
     }
   }


### PR DESCRIPTION
Addresses 2 categories of issues:
1. Make the result writer always use system line separators because combining different types prevented tests from being fixable
2. Fix all the tests that assert multi-line strings to use the system line separator

Note that we'll continue to see about 24 failing tests on Windows due to several incompatibilities with file I/O unrelated to line separators