### PR TITLE
Improved array copy performance

### DIFF
--- a/strikt-core/src/main/kotlin/strikt/assertions/Iterable.kt
+++ b/strikt-core/src/main/kotlin/strikt/assertions/Iterable.kt
@@ -292,7 +292,7 @@ fun <T : Iterable<E>, E> Builder<T>.exactly(
  * If either the subject or [elements] are empty the assertion always fails.
  */
 fun <T : Iterable<E>, E> Builder<T>.contains(vararg elements: E): Builder<T> =
-  contains(elements.toList())
+  contains(elements.asList())
 
 /**
  * Asserts that all [elements] are present in the subject.
@@ -334,16 +334,16 @@ infix fun <T : Iterable<E>, E> Builder<T>.contains(elements: Collection<E>): Bui
  * Asserts that none of [elements] are present in the subject.
  *
  * If [elements] is empty the assertion always fails.
- * If the subject is empty the assertion always passe.
+ * If the subject is empty the assertion always passes.
  */
 fun <T : Iterable<E>, E> Builder<T>.doesNotContain(vararg elements: E): Builder<T> =
-  doesNotContain(elements.toList())
+  doesNotContain(elements.asList())
 
 /**
  * Asserts that none of [elements] are present in the subject.
  *
  * If [elements] is empty the assertion always fails.
- * If the subject is empty the assertion always passe.
+ * If the subject is empty the assertion always passes.
  */
 infix fun <T : Iterable<E>, E> Builder<T>.doesNotContain(elements: Collection<E>): Builder<T> =
   when {
@@ -382,7 +382,7 @@ infix fun <T : Iterable<E>, E> Builder<T>.doesNotContain(elements: Collection<E>
  * [containsExactlyInAnyOrder] instead.
  */
 fun <T : Iterable<E>, E> Builder<T>.containsExactly(vararg elements: E): Builder<T> =
-  containsExactly(elements.toList())
+  containsExactly(elements.asList())
 
 /**
  * Asserts that all [elements] _and no others_ are present in the subject in the
@@ -430,7 +430,7 @@ infix fun <T : Iterable<E>, E> Builder<T>.containsExactly(elements: Collection<E
  * regardless of what order they appear in.
  */
 fun <T : Iterable<E>, E> Builder<T>.containsExactlyInAnyOrder(vararg elements: E): Builder<T> =
-  containsExactlyInAnyOrder(elements.toList())
+  containsExactlyInAnyOrder(elements.asList())
 
 /**
  * Asserts that all [elements] _and no others_ are present in the subject.

--- a/strikt-core/src/main/kotlin/strikt/assertions/List.kt
+++ b/strikt-core/src/main/kotlin/strikt/assertions/List.kt
@@ -23,7 +23,7 @@ operator fun <T : List<E>, E> Builder<T>.get(range: IntRange): Builder<List<E>> 
  * Asserts that all [elements] are present in the subject in exactly the same order
  */
 fun <T : List<E>, E> Builder<T>.containsSequence(vararg elements: E) =
-  containsSequence(elements.toList())
+  containsSequence(elements.asList())
 
 /**
  * Asserts that all [elements] are present in the subject in exactly the same order

--- a/strikt-core/src/main/kotlin/strikt/assertions/Map.kt
+++ b/strikt-core/src/main/kotlin/strikt/assertions/Map.kt
@@ -85,7 +85,7 @@ infix fun <T : Map<K, V>, K, V> Builder<T>.doesNotContainKey(key: K): Builder<T>
  * Asserts that the subject map contains entries for all [keys].
  */
 fun <T : Map<K, V>, K, V> Builder<T>.containsKeys(vararg keys: K): Builder<T> =
-  compose("has entries with the keys %s", keys.toList()) {
+  compose("has entries with the keys %s", keys.asList()) {
     keys.forEach { key -> containsKey(key) }
   } then {
     if (allPassed) pass() else fail()
@@ -95,7 +95,7 @@ fun <T : Map<K, V>, K, V> Builder<T>.containsKeys(vararg keys: K): Builder<T> =
  * Asserts that the subject map doesn't contain entries for all [keys].
  */
 fun <T : Map<K, V>, K, V> Builder<T>.doesNotContainKeys(vararg keys: K): Builder<T> =
-  compose("doesn't have entries with the keys %s", keys.toList()) {
+  compose("doesn't have entries with the keys %s", keys.asList()) {
     keys.forEach { key -> doesNotContainKey(key) }
   } then {
     if (allPassed) pass() else fail()


### PR DESCRIPTION
Hi, thanks for creating such a nice library.
I would like to suggest a minor change.

#### 1. Use `Array.asList()` instead of `Array.toList()`.

As I understand it, `Array.toList()` copies the array elements and converts them to a List. But `Array.asList()` wraps the array itself as a `List`. (No element copying)

#### 2. correct `passe` to `passes`

I think you guys meant `passes`.

If this was your intention, please feel free to close this PR.
Thanks!