### PR TITLE
Only render subject description on failure

### DIFF
--- a/strikt-core/src/main/kotlin/strikt/internal/AssertionBuilder.kt
+++ b/strikt-core/src/main/kotlin/strikt/internal/AssertionBuilder.kt
@@ -17,14 +17,14 @@ internal class AssertionBuilder<T>(
 
   override fun describedAs(description: String): Builder<T> {
     if (context is DescribedNode<*>) {
-      context.description = description
+      context.description = { description }
     }
     return this
   }
 
   override fun describedAs(descriptor: T.() -> String): Builder<T> {
     if (context is DescribedNode<*>) {
-      context.description = context.subject.descriptor()
+      context.description = { context.subject.descriptor() }
     }
     return this
   }
@@ -98,14 +98,14 @@ internal class AssertionBuilder<T>(
     }
 
   override fun <R> get(
-    description: String,
+    description: () -> String,
     function: (T) -> R
   ): DescribeableBuilder<R> =
     if (context.allowChain) {
       runCatching {
         function(context.subject)
       }
-        .getOrElse { ex -> throw MappingFailed(description, ex) }
+        .getOrElse { ex -> throw MappingFailed(description(), ex) }
         .let {
           AssertionBuilder(
             AssertionSubject(context, it, description),
@@ -121,7 +121,7 @@ internal class AssertionBuilder<T>(
     }
 
   override fun <R> with(
-    description: String,
+    description: () -> String,
     function: T.() -> R,
     block: Builder<R>.() -> Unit
   ): Builder<T> {
@@ -135,7 +135,7 @@ internal class AssertionBuilder<T>(
             strategy.evaluate(nestedContext)
           }
       }
-      .onFailure { ex -> throw MappingFailed(description, ex) }
+      .onFailure { ex -> throw MappingFailed(description(), ex) }
     return this
   }
 

--- a/strikt-core/src/main/kotlin/strikt/internal/AssertionNode.kt
+++ b/strikt-core/src/main/kotlin/strikt/internal/AssertionNode.kt
@@ -23,7 +23,7 @@ internal interface AssertionNode<S> {
 }
 
 internal interface DescribedNode<S> : AssertionNode<S> {
-  var description: String
+  var description: () -> String
 }
 
 internal interface AssertionGroup<S> : AssertionNode<S> {
@@ -39,7 +39,7 @@ internal interface AssertionResult<S> : DescribedNode<S> {
 internal class AssertionSubject<S>(
   override val parent: AssertionGroup<*>?,
   override val subject: S,
-  override var description: String = "%s"
+  override var description: () -> String = { "%s" }
 ) : AssertionGroup<S>, DescribedNode<S> {
   constructor(value: S) : this(null, value)
 
@@ -138,7 +138,7 @@ internal class AssertionChainedGroup<S>(
 
 internal abstract class AtomicAssertionNode<S>(
   final override val parent: AssertionGroup<S>,
-  override var description: String,
+  override var description: () -> String,
   override val expected: Any? = null
 ) : AssertionResult<S>, AtomicAssertion {
 
@@ -156,7 +156,7 @@ internal abstract class AtomicAssertionNode<S>(
 
 internal abstract class CompoundAssertionNode<S>(
   final override val parent: AssertionGroup<S>,
-  override var description: String,
+  override var description: () -> String,
   override val expected: Any? = null
 ) : AssertionGroup<S>, AssertionResult<S>, CompoundAssertion {
 

--- a/strikt-core/src/main/kotlin/strikt/internal/AssertionStrategy.kt
+++ b/strikt-core/src/main/kotlin/strikt/internal/AssertionStrategy.kt
@@ -20,7 +20,7 @@ internal sealed class AssertionStrategy {
   ): AtomicAssertionNode<T> =
     object : AtomicAssertionNode<T>(
       context,
-      provideDescription(description),
+      { provideDescription(description) },
       expected
     ) {
 
@@ -62,7 +62,7 @@ internal sealed class AssertionStrategy {
   ): CompoundAssertionNode<T> =
     object : CompoundAssertionNode<T>(
       context,
-      provideDescription(description),
+      { provideDescription(description) },
       expected
     ) {
 

--- a/strikt-core/src/main/kotlin/strikt/internal/reporting/DefaultResultWriter.kt
+++ b/strikt-core/src/main/kotlin/strikt/internal/reporting/DefaultResultWriter.kt
@@ -82,6 +82,7 @@ internal open class DefaultResultWriter : ResultWriter {
     if (isRoot) {
       writer.append("Expect that ")
     }
+    val description = this.description()
     // if the value spans > 1 line, this is how much to indent following lines
     val valueIndent =
       (description.indexOf("%")).coerceAtLeast(0) + 14 + (indent * 2)
@@ -104,6 +105,7 @@ internal open class DefaultResultWriter : ResultWriter {
     val failed = status as? Failed
     when {
       failed?.comparison != null -> {
+        val description = this.description()
         val formattedComparison = failed.comparison.formatValues()
         val failedDescription = failed.description ?: "found %s"
         val descriptionIndent = description.indexOf("%")
@@ -143,10 +145,10 @@ internal open class DefaultResultWriter : ResultWriter {
       }
       failed?.description != null ->
         writer
-          .append(description.format(formatValue(expected)))
+          .append(description().format(formatValue(expected)))
           .append(" : ")
           .append(failed.description)
-      else -> writer.append(description.format(formatValue(expected)))
+      else -> writer.append(description().format(formatValue(expected)))
     }
   }
 


### PR DESCRIPTION
Use a lambda to lazily render the subject description only when the test fails. This significantly speeds up the test execution. In particular, this can really help property based tests where thousands of tests may be executed.

Constructing an exception is relatively fast and it captures the stack trace. Converting the stack trace from the internal representation to Java StackTraceElements is very costly (i.e. calling ex.getStackTrace). I had to recreate getCallerInfo from FilePeek to accept an exception rather than creating one internally. I submitted a [PR](https://github.com/christophsturm/filepeek/pull/14/) to filepeek that adds a getCallerInfo that accepts an exception.

This super contrived test goes from 10.6 seconds to 1.1s (on my machine). 

```kotlin
@Test
fun `get perf`() {
  class Person(val id: Int)
  val range = Int.MIN_VALUE..Int.MAX_VALUE

  repeat(10_000) {
    expectThat(Person(Random.nextInt())) {
      get { id } isIn range
      get { id } isIn range
      get { id } isIn range
      get { id } isIn range
      get { id } isIn range
      get { id } isIn range
      get { id } isIn range
      get { id } isIn range
      get { id } isIn range
      get { id } isIn range
      get { id } isIn range
      get { id } isIn range
      get { id } isIn range
      get { id } isIn range
      get { id } isIn range
      get { id } isIn range
      get { id } isIn range
      get { id } isIn range
      get { id } isIn range
      get { id } isIn range
      get { id } isIn range
      get { id } isIn range
      get { id } isIn range
      get { id } isIn range
      get { id } isIn range
      get { id } isIn range
      get { id } isIn range
      get { id } isIn range
    }
  }
}
```