### PR TITLE
Use correct subject description when using with passing a lambda 

### DIFF
--- a/strikt-core/src/main/kotlin/strikt/api/Assertion.kt
+++ b/strikt-core/src/main/kotlin/strikt/api/Assertion.kt
@@ -325,9 +325,9 @@ interface Assertion {
 private fun <Receiver, Result> (Receiver.() -> Result).describe(name: String): String =
   when (this) {
     is KProperty<*> ->
-      "value of property ${this.name}"
+      "value of property $name"
     is KFunction<*> ->
-      "return value of ${this.name}"
+      "return value of $name"
     is CallableReference -> "value of $propertyName"
     else -> {
       try {

--- a/strikt-core/src/main/kotlin/strikt/api/Assertion.kt
+++ b/strikt-core/src/main/kotlin/strikt/api/Assertion.kt
@@ -217,7 +217,7 @@ interface Assertion {
      * [function].
      */
     fun <R> get(function: T.() -> R): DescribeableBuilder<R> =
-      get(function.describe(), function)
+      get(function.describe("get"), function)
 
     /**
      * Runs a group of assertions on the subject returned by [function].
@@ -322,7 +322,7 @@ interface Assertion {
   }
 }
 
-private fun <Receiver, Result> (Receiver.() -> Result).describe(name: String = "get"): String =
+private fun <Receiver, Result> (Receiver.() -> Result).describe(name: String): String =
   when (this) {
     is KProperty<*> ->
       "value of property ${this.name}"

--- a/strikt-core/src/main/kotlin/strikt/api/Assertion.kt
+++ b/strikt-core/src/main/kotlin/strikt/api/Assertion.kt
@@ -247,7 +247,7 @@ interface Assertion {
     fun <R> with(
       function: T.() -> R,
       block: Builder<R>.() -> Unit
-    ) = with(function.describe(), function, block)
+    ) = with(function.describe("with"), function, block)
 
     /**
      * Maps the assertion subject to the result of [function].
@@ -322,17 +322,17 @@ interface Assertion {
   }
 }
 
-private fun <Receiver, Result> (Receiver.() -> Result).describe(): String =
+private fun <Receiver, Result> (Receiver.() -> Result).describe(name: String = "get"): String =
   when (this) {
     is KProperty<*> ->
-      "value of property $name"
+      "value of property ${this.name}"
     is KFunction<*> ->
-      "return value of $name"
+      "return value of ${this.name}"
     is CallableReference -> "value of $propertyName"
     else -> {
       try {
         val line = FilePeek.filePeek.getCallerFileInfo().line
-        LambdaBody("get", line).body.trim()
+        LambdaBody(name, line).body.trim()
       } catch (e: Exception) {
         "%s"
       }

--- a/strikt-core/src/test/kotlin/strikt/Formatting.kt
+++ b/strikt-core/src/test/kotlin/strikt/Formatting.kt
@@ -160,7 +160,7 @@ internal class Formatting {
 
   @Test
   fun `property name is used when using a lambda`() {
-    val subject = Mapping.Person("David", LocalDate.of(1947, 1, 8))
+    val subject = Person("David", LocalDate.of(1947, 1, 8))
 
     val error = assertThrows<AssertionError> {
       expectThat(subject).get { birthDate }
@@ -178,8 +178,27 @@ internal class Formatting {
   }
 
   @Test
-  fun `property name is used when nesting using with and a lambda`() {
-    val subject = Mapping.Person("David", LocalDate.of(1947, 1, 8))
+  fun `property name is used when using a property`() {
+    val subject = Person("David", LocalDate.of(1947, 1, 8))
+
+    val error = assertThrows<AssertionError> {
+      expectThat(subject).get(Person::birthDate)
+        .get(LocalDate::getYear)
+        .isEqualTo(1971)
+    }
+
+    expectThat(error.message).isEqualTo(
+      """▼ Expect that Person(name=David, birthDate=1947-01-08):
+          |  ▼ value of property birthDate:
+          |    ▼ return value of getYear:
+          |      ✗ is equal to 1971
+          |              found 1947""".trimMargin()
+    )
+  }
+
+  @Test
+  fun `property name is used when using with and a lambda`() {
+    val subject = Person("David", LocalDate.of(1947, 1, 8))
 
     val error = assertThrows<AssertionError> {
       expectThat(subject) {
@@ -192,6 +211,27 @@ internal class Formatting {
     expectThat(error.message).isEqualTo(
       """▼ Expect that Person(name=David, birthDate=1947-01-08):
           |  ▼ birthDate:
+          |    ▼ year:
+          |      ✗ is equal to 1971
+          |              found 1947""".trimMargin()
+    )
+  }
+
+  @Test
+  fun `property name is used when using with and a property`() {
+    val subject = Person("David", LocalDate.of(1947, 1, 8))
+
+    val error = assertThrows<AssertionError> {
+      expectThat(subject) {
+        with(Person::birthDate) {
+          get { year }.isEqualTo(1971)
+        }
+      }
+    }
+
+    expectThat(error.message).isEqualTo(
+      """▼ Expect that Person(name=David, birthDate=1947-01-08):
+          |  ▼ value of property birthDate:
           |    ▼ year:
           |      ✗ is equal to 1971
           |              found 1947""".trimMargin()

--- a/strikt-core/src/test/kotlin/strikt/Formatting.kt
+++ b/strikt-core/src/test/kotlin/strikt/Formatting.kt
@@ -5,7 +5,14 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import strikt.api.expectThat
-import strikt.assertions.*
+import strikt.assertions.all
+import strikt.assertions.contains
+import strikt.assertions.hasSize
+import strikt.assertions.isEqualTo
+import strikt.assertions.isNotEqualTo
+import strikt.assertions.isNotNull
+import strikt.assertions.isUpperCase
+import strikt.assertions.startsWith
 import java.time.LocalDate
 
 @DisplayName("error message formatting")

--- a/strikt-core/src/test/kotlin/strikt/Formatting.kt
+++ b/strikt-core/src/test/kotlin/strikt/Formatting.kt
@@ -4,14 +4,8 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import strikt.api.expectThat
-import strikt.assertions.all
-import strikt.assertions.contains
-import strikt.assertions.hasSize
-import strikt.assertions.isEqualTo
-import strikt.assertions.isNotEqualTo
-import strikt.assertions.isNotNull
-import strikt.assertions.isUpperCase
-import strikt.assertions.startsWith
+import strikt.assertions.*
+import java.time.LocalDate
 
 @DisplayName("error message formatting")
 internal class Formatting {
@@ -161,6 +155,46 @@ internal class Formatting {
         |          found "a string
         |                |with
         |                |line breaks"""".trimMargin()
+    )
+  }
+
+  @Test
+  fun `property name is used when using a lambda`() {
+    val subject = Mapping.Person("David", LocalDate.of(1947, 1, 8))
+
+    val error = assertThrows<AssertionError> {
+      expectThat(subject).get { birthDate }
+        .get(LocalDate::getYear)
+        .isEqualTo(1971)
+    }
+
+    expectThat(error.message).isEqualTo(
+      """▼ Expect that Person(name=David, birthDate=1947-01-08):
+          |  ▼ birthDate:
+          |    ▼ return value of getYear:
+          |      ✗ is equal to 1971
+          |              found 1947""".trimMargin()
+    )
+  }
+
+  @Test
+  fun `property name is used when nesting using with and a lambda`() {
+    val subject = Mapping.Person("David", LocalDate.of(1947, 1, 8))
+
+    val error = assertThrows<AssertionError> {
+      expectThat(subject) {
+        with({ birthDate }) {
+          get { year }.isEqualTo(1971)
+        }
+      }
+    }
+
+    expectThat(error.message).isEqualTo(
+      """▼ Expect that Person(name=David, birthDate=1947-01-08):
+          |  ▼ birthDate:
+          |    ▼ year:
+          |      ✗ is equal to 1971
+          |              found 1947""".trimMargin()
     )
   }
 }

--- a/strikt-core/src/test/kotlin/strikt/Formatting.kt
+++ b/strikt-core/src/test/kotlin/strikt/Formatting.kt
@@ -6,8 +6,6 @@ import org.junit.jupiter.api.assertThrows
 import strikt.api.expectThat
 import strikt.assertions.*
 import java.time.LocalDate
-import kotlin.jvm.internal.CallableReference
-import kotlin.reflect.KProperty0
 
 @DisplayName("error message formatting")
 internal class Formatting {
@@ -240,5 +238,3 @@ internal class Formatting {
     )
   }
 }
-
-fun Person.lastName() = "$name last"

--- a/strikt-core/src/test/kotlin/strikt/Formatting.kt
+++ b/strikt-core/src/test/kotlin/strikt/Formatting.kt
@@ -173,7 +173,7 @@ internal class Formatting {
     @DisplayName("when using get")
     inner class Get {
       @Test
-      fun `is the property name when using a lambda`() {
+      fun `is the property name when passing a lambda`() {
         val subject = Person("David", LocalDate.of(1947, 1, 8))
 
         val error = assertThrows<AssertionError> {
@@ -192,7 +192,7 @@ internal class Formatting {
       }
 
       @Test
-      fun `is the property name when using a property`() {
+      fun `is the property name when passing a property`() {
         val subject = Person("David", LocalDate.of(1947, 1, 8))
 
         val error = assertThrows<AssertionError> {
@@ -215,7 +215,7 @@ internal class Formatting {
     @DisplayName("when using with")
     inner class With {
       @Test
-      fun `is the property name when using a lambda`() {
+      fun `is the property name when passing a lambda`() {
         val subject = Person("David", LocalDate.of(1947, 1, 8))
 
         val error = assertThrows<AssertionError> {
@@ -236,7 +236,7 @@ internal class Formatting {
       }
 
       @Test
-      fun `is property name when using a property`() {
+      fun `is property name when passing a property`() {
         val subject = Person("David", LocalDate.of(1947, 1, 8))
 
         val error = assertThrows<AssertionError> {

--- a/strikt-core/src/test/kotlin/strikt/Formatting.kt
+++ b/strikt-core/src/test/kotlin/strikt/Formatting.kt
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.assertThrows
 import strikt.api.expectThat
 import strikt.assertions.*
 import java.time.LocalDate
+import kotlin.jvm.internal.CallableReference
+import kotlin.reflect.KProperty0
 
 @DisplayName("error message formatting")
 internal class Formatting {
@@ -238,3 +240,5 @@ internal class Formatting {
     )
   }
 }
+
+fun Person.lastName() = "$name last"

--- a/strikt-core/src/test/kotlin/strikt/Formatting.kt
+++ b/strikt-core/src/test/kotlin/strikt/Formatting.kt
@@ -1,6 +1,7 @@
 package strikt
 
 import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import strikt.api.expectThat
@@ -158,83 +159,95 @@ internal class Formatting {
     )
   }
 
-  @Test
-  fun `property name is used when using a lambda`() {
-    val subject = Person("David", LocalDate.of(1947, 1, 8))
+  @Nested
+  @DisplayName("subject description")
+  inner class SubjectDescription {
+    @Nested
+    @DisplayName("when using get")
+    inner class Get {
+      @Test
+      fun `is the property name when using a lambda`() {
+        val subject = Person("David", LocalDate.of(1947, 1, 8))
 
-    val error = assertThrows<AssertionError> {
-      expectThat(subject).get { birthDate }
-        .get(LocalDate::getYear)
-        .isEqualTo(1971)
-    }
+        val error = assertThrows<AssertionError> {
+          expectThat(subject).get { birthDate }
+            .get(LocalDate::getYear)
+            .isEqualTo(1971)
+        }
 
-    expectThat(error.message).isEqualTo(
-      """▼ Expect that Person(name=David, birthDate=1947-01-08):
+        expectThat(error.message).isEqualTo(
+          """▼ Expect that Person(name=David, birthDate=1947-01-08):
           |  ▼ birthDate:
           |    ▼ return value of getYear:
           |      ✗ is equal to 1971
           |              found 1947""".trimMargin()
-    )
-  }
+        )
+      }
 
-  @Test
-  fun `property name is used when using a property`() {
-    val subject = Person("David", LocalDate.of(1947, 1, 8))
+      @Test
+      fun `is the property name when using a property`() {
+        val subject = Person("David", LocalDate.of(1947, 1, 8))
 
-    val error = assertThrows<AssertionError> {
-      expectThat(subject).get(Person::birthDate)
-        .get(LocalDate::getYear)
-        .isEqualTo(1971)
-    }
+        val error = assertThrows<AssertionError> {
+          expectThat(subject).get(Person::birthDate)
+            .get(LocalDate::getYear)
+            .isEqualTo(1971)
+        }
 
-    expectThat(error.message).isEqualTo(
-      """▼ Expect that Person(name=David, birthDate=1947-01-08):
+        expectThat(error.message).isEqualTo(
+          """▼ Expect that Person(name=David, birthDate=1947-01-08):
           |  ▼ value of property birthDate:
           |    ▼ return value of getYear:
           |      ✗ is equal to 1971
           |              found 1947""".trimMargin()
-    )
-  }
-
-  @Test
-  fun `property name is used when using with and a lambda`() {
-    val subject = Person("David", LocalDate.of(1947, 1, 8))
-
-    val error = assertThrows<AssertionError> {
-      expectThat(subject) {
-        with({ birthDate }) {
-          get { year }.isEqualTo(1971)
-        }
+        )
       }
     }
 
-    expectThat(error.message).isEqualTo(
-      """▼ Expect that Person(name=David, birthDate=1947-01-08):
+    @Nested
+    @DisplayName("when using with")
+    inner class With {
+      @Test
+      fun `is the property name when using a lambda`() {
+        val subject = Person("David", LocalDate.of(1947, 1, 8))
+
+        val error = assertThrows<AssertionError> {
+          expectThat(subject) {
+            with({ birthDate }) {
+              get { year }.isEqualTo(1971)
+            }
+          }
+        }
+
+        expectThat(error.message).isEqualTo(
+          """▼ Expect that Person(name=David, birthDate=1947-01-08):
           |  ▼ birthDate:
           |    ▼ year:
           |      ✗ is equal to 1971
           |              found 1947""".trimMargin()
-    )
-  }
-
-  @Test
-  fun `property name is used when using with and a property`() {
-    val subject = Person("David", LocalDate.of(1947, 1, 8))
-
-    val error = assertThrows<AssertionError> {
-      expectThat(subject) {
-        with(Person::birthDate) {
-          get { year }.isEqualTo(1971)
-        }
+        )
       }
-    }
 
-    expectThat(error.message).isEqualTo(
-      """▼ Expect that Person(name=David, birthDate=1947-01-08):
+      @Test
+      fun `is property name when using a property`() {
+        val subject = Person("David", LocalDate.of(1947, 1, 8))
+
+        val error = assertThrows<AssertionError> {
+          expectThat(subject) {
+            with(Person::birthDate) {
+              get { year }.isEqualTo(1971)
+            }
+          }
+        }
+
+        expectThat(error.message).isEqualTo(
+          """▼ Expect that Person(name=David, birthDate=1947-01-08):
           |  ▼ value of property birthDate:
           |    ▼ year:
           |      ✗ is equal to 1971
           |              found 1947""".trimMargin()
-    )
+        )
+      }
+    }
   }
 }


### PR DESCRIPTION
When creating a nested assertion using `with` passing a lambda, the property description is incorrect:

```kotlin
val subject = Person("David", LocalDate.of(1947, 1, 8))
expectThat(subject) {
   with({ birthDate }) {
       get { year }.isEqualTo(1971)
    }
}
```
produces:
```
▼ Expect that Person(name=David, birthDate=1947-01-08):
  ▼ year:
    ▼ year:
      ✗ is equal to 1971
              found 1947
```

but it should be:
```
▼ Expect that Person(name=David, birthDate=1947-01-08):
  ▼ birthDate:
    ▼ year:
      ✗ is equal to 1971
              found 1947
```

The same should be happening when passing a `CallableReference` to `with`, but I don't know how to reproduce the issue.

fixes #252 