### PR TITLE
Add Iterable assertion builder with constraint-based order matching

### DIFF
--- a/strikt-core/src/main/kotlin/strikt/internal/iterable/AssertionOrderingConstraints.kt
+++ b/strikt-core/src/main/kotlin/strikt/internal/iterable/AssertionOrderingConstraints.kt
@@ -1,0 +1,97 @@
+package strikt.internal.iterable
+
+import strikt.assertions.OrderingConstraintsAssertScope
+import strikt.assertions.OrderingConstraintsBuilder
+
+internal class OrderingConstraintsAssertScopeImpl<E>: OrderingConstraintsAssertScope<E> {
+
+  val sections = mutableListOf<SectionAssertionSpec<E>>()
+  var currentBuildingSection = SectionAssertionSpec<E>()
+  var expectsNoFurtherElements = false
+
+  override fun expect(element: E): OrderingConstraintsBuilder<E> {
+    require(!expectsNoFurtherElements) { "expectNoFurtherElements was previously called" }
+    require(currentBuildingSection.elementsWithConstraints.none { it.element == element }) {
+      "Element $element already expected in this section!\n" +
+        "Use startNewSection if this element is expected to be in the list multiple times. " +
+        "Ordering constraints are asserted within each section."
+    }
+    val constraintsBuilder = OrderingConstraintsBuilderImpl(currentBuildingSection)
+    currentBuildingSection.elementsWithConstraints +=
+      ElementWithOrderingConstraints(element, constraintsBuilder.constraints)
+    return constraintsBuilder
+  }
+
+  override fun expectNoFurtherElements() {
+    expectsNoFurtherElements = true
+  }
+
+  override fun startNewSection() = endSectionIfInProgress()
+
+  fun endSectionIfInProgress() {
+    if (currentBuildingSection.elementsWithConstraints.isEmpty()) return
+    sections += currentBuildingSection
+    currentBuildingSection = SectionAssertionSpec()
+  }
+
+  internal class OrderingConstraintsBuilderImpl<E>(
+    private val section: SectionAssertionSpec<E>,
+  ) : OrderingConstraintsBuilder<E> {
+
+    val constraints = mutableListOf<OrderingConstraint<E>>()
+
+    override fun first(): OrderingConstraintsBuilderImpl<E> {
+      constraints += OrderingConstraint.First
+      return this
+    }
+
+    override fun last(): OrderingConstraintsBuilderImpl<E> {
+      constraints += OrderingConstraint.Last
+      return this
+    }
+
+    override fun before(other: E): OrderingConstraintsBuilderImpl<E> {
+      constraints += OrderingConstraint.Before(other)
+      return this
+    }
+
+    override fun immediatelyBefore(other: E): OrderingConstraintsBuilder<E> {
+      constraints += OrderingConstraint.ImmediatelyBefore(other)
+      return this
+    }
+
+    override fun after(other: E): OrderingConstraintsBuilderImpl<E> {
+      constraints += OrderingConstraint.After(other)
+      return this
+    }
+
+    override fun immediatelyAfter(other: E): OrderingConstraintsBuilder<E> {
+      constraints += OrderingConstraint.ImmediatelyAfter(other)
+      return this
+    }
+
+    override fun immediatelyAfterPrevious(): OrderingConstraintsBuilderImpl<E> {
+      require(section.elementsWithConstraints.isNotEmpty()) {
+        "immediatelyAfterPrevious requires declaring an expected element before this one"
+      }
+      constraints += OrderingConstraint.ImmediatelyAfterPrevious
+      return this
+    }
+  }
+}
+
+internal data class ElementWithOrderingConstraints<E>(val element: E, val constraints: List<OrderingConstraint<E>>)
+
+internal class SectionAssertionSpec<E> {
+  val elementsWithConstraints = mutableListOf<ElementWithOrderingConstraints<E>>()
+}
+
+internal sealed class OrderingConstraint<out E> {
+  data object First: OrderingConstraint<Nothing>()
+  data object Last: OrderingConstraint<Nothing>()
+  data class Before<E>(val target: E) : OrderingConstraint<E>()
+  data class ImmediatelyBefore<E>(val target: E) : OrderingConstraint<E>()
+  data class After<E>(val target: E) : OrderingConstraint<E>()
+  data class ImmediatelyAfter<E>(val target: E) : OrderingConstraint<E>()
+  data object ImmediatelyAfterPrevious : OrderingConstraint<Nothing>()
+}

--- a/strikt-core/src/test/kotlin/strikt/assertions/IterableOrderingConstraintsAssertions.kt
+++ b/strikt-core/src/test/kotlin/strikt/assertions/IterableOrderingConstraintsAssertions.kt
@@ -1,0 +1,340 @@
+package strikt.assertions
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import strikt.api.expectThat
+
+/** Tests for [containsWithOrderingConstraints] */
+class IterableOrderingConstraintsAssertions {
+
+  @Test
+  fun simpleAfter() {
+    expectThat(listOf("a", "b"))
+      .containsWithOrderingConstraints {
+        expect("a")
+        expect("b").after("a")
+      }
+  }
+
+  @Test
+  fun simpleAfterFailure() {
+    assertThrows<AssertionError> {
+      expectThat(listOf("b", "a"))
+        .containsWithOrderingConstraints {
+          expect("a")
+          expect("b").after("a")
+        }
+    }
+  }
+
+  @Test
+  fun simpleAfterNotInOrder() {
+    expectThat(listOf("a", "b"))
+      .containsWithOrderingConstraints {
+        expect("b").after("a")
+        expect("a")
+      }
+  }
+
+  @Test
+  fun simpleAfterNotInOrderFailure() {
+    assertThrows<AssertionError> {
+      expectThat(listOf("b", "a"))
+        .containsWithOrderingConstraints {
+          expect("b").after("a")
+          expect("a")
+        }
+    }
+  }
+
+  @Test
+  fun simpleBefore() {
+    expectThat(listOf("a", "b"))
+      .containsWithOrderingConstraints {
+        expect("a").before("b")
+        expect("b")
+      }
+  }
+
+  @Test
+  fun simpleBeforeFailure() {
+    assertThrows<AssertionError> {
+      expectThat(listOf("b", "a"))
+        .containsWithOrderingConstraints {
+          expect("a").before("b")
+          expect("b")
+        }
+    }
+  }
+
+  @Test
+  fun simpleBeforeNotInOrder() {
+    expectThat(listOf("a", "b"))
+      .containsWithOrderingConstraints {
+        expect("b")
+        expect("a").before("b")
+      }
+  }
+
+  @Test
+  fun simpleBeforeNotInOrderFailure() {
+    assertThrows<AssertionError> {
+      expectThat(listOf("b", "a"))
+        .containsWithOrderingConstraints {
+          expect("b")
+          expect("a").before("b")
+        }
+    }
+  }
+
+  @Test
+  fun beforeAndAfter() {
+    expectThat(listOf("a", "b"))
+      .containsWithOrderingConstraints {
+        expect("a").before("b")
+        expect("b").after("a")
+      }
+  }
+
+  @Test
+  fun immediatelyBeforeAndImmediatelyAfter() {
+    expectThat(listOf("a", "b", "c", "d"))
+      .containsWithOrderingConstraints {
+        expect("a").immediatelyBefore("b")
+        expect("b")
+          .immediatelyAfter("a")
+          .immediatelyBefore("c")
+        expect("c")
+          .immediatelyAfter("b")
+          .immediatelyBefore("d")
+        expect("d").immediatelyAfter("c")
+      }
+  }
+
+  @Test
+  fun immediatelyBeforeFailure() {
+    assertThrows<AssertionError> {
+      expectThat(listOf("a", "b", "c"))
+        .containsWithOrderingConstraints {
+          expect("a").immediatelyBefore("c")
+        }
+    }
+  }
+
+  @Test
+  fun immediatelyAfterFailure() {
+    assertThrows<AssertionError> {
+      expectThat(listOf("a", "b", "c"))
+        .containsWithOrderingConstraints {
+          expect("c").immediatelyAfter("a")
+        }
+    }
+  }
+
+  @Test
+  fun afterMissingElementFails() {
+    assertThrows<AssertionError> {
+      expectThat(listOf("a", "b_wrong", "c"))
+        .containsWithOrderingConstraints {
+          expect("a")
+          expect("c").after("b")
+        }
+    }
+  }
+
+  @Test
+  fun firstImmediatelyAfterPreviousAndLast() {
+    expectThat(listOf("a", "b", "c", "d"))
+      .containsWithOrderingConstraints {
+        expect("a").first()
+        expect("b").immediatelyAfterPrevious()
+        expect("c").immediatelyAfterPrevious()
+        expect("d").last()
+      }
+  }
+
+  @Test
+  fun beforeAndAfterInDeclaredOrder() {
+    expectThat(listOf("a", "b", "c", "d"))
+      .containsWithOrderingConstraints {
+        expect("a").before("d")
+        expect("b").after("a").before("d")
+        expect("c").after("a").after("b").before("d")
+        expect("d").after("a")
+      }
+  }
+
+  @Test
+  fun beforeAndAfterInDeclaredOrderFails() {
+    assertThrows<AssertionError> {
+      expectThat(listOf("a", "b", "d", "c"))
+        .containsWithOrderingConstraints {
+          expect("a").before("d")
+          expect("b").after("a").before("d")
+          expect("c").after("a").after("b").before("d")
+          expect("d").after("a")
+        }
+    }
+  }
+
+  @Test
+  fun beforeAndAfterNotInDeclaredOrder() {
+    expectThat(listOf("a", "b", "c", "d"))
+      .containsWithOrderingConstraints {
+        expect("d").after("a")
+        expect("a").before("d")
+        expect("c").after("a").after("b").before("d")
+        expect("b").after("a").before("d")
+      }
+  }
+
+  @Test
+  fun beforeAndAfterNotInDeclaredOrderFails() {
+    assertThrows<AssertionError> {
+      expectThat(listOf("a", "b", "d", "c"))
+        .containsWithOrderingConstraints {
+          expect("d").after("a")
+          expect("a").before("d")
+          expect("c").after("a").after("b").before("d")
+          expect("b").after("a").before("d")
+        }
+    }
+  }
+
+  @Test
+  fun failsWithMissingElements() {
+    assertThrows<AssertionError> {
+      expectThat(listOf("a", "b", "c"))
+        .containsWithOrderingConstraints {
+          expect("a").first()
+          expect("b").immediatelyAfterPrevious()
+          expect("c").immediatelyAfterPrevious()
+          expect("d").last()
+        }
+    }
+  }
+
+  @Test
+  fun passesWithExtraElement() {
+    expectThat(listOf("a", "b", "c", "d"))
+      .containsWithOrderingConstraints {
+        expect("a").first()
+        expect("b").immediatelyAfterPrevious()
+        expect("c").immediatelyAfterPrevious()
+      }
+  }
+
+  @Test
+  fun failsWithExtraElementAndExpectNoFurtherElements() {
+    assertThrows<AssertionError> {
+      expectThat(listOf("a", "b", "c", "d"))
+        .containsWithOrderingConstraints {
+          expect("a").first()
+          expect("b").immediatelyAfterPrevious()
+          expect("c").immediatelyAfterPrevious()
+          expectNoFurtherElements()
+        }
+    }
+  }
+
+  @Test
+  fun failsWithExtraElementAfterExpectedLast() {
+    assertThrows<AssertionError> {
+      expectThat(listOf("a", "b", "c", "d"))
+        .containsWithOrderingConstraints {
+          expect("a").first()
+          expect("b").immediatelyAfterPrevious()
+          expect("c").last()
+        }
+    }
+  }
+
+  @Test
+  fun failsWithDuplicateElement() {
+    assertThrows<AssertionError> {
+      expectThat(listOf("a", "b", "b", "c"))
+        .containsWithOrderingConstraints {
+          expect("a").first()
+          expect("b").immediatelyAfterPrevious()
+          expect("c").last()
+        }
+    }
+  }
+
+  @Test
+  fun failsWithDuplicateAssertedElement() {
+    assertThrows<IllegalArgumentException> {
+      expectThat(listOf("a", "b", "b", "c"))
+        .containsWithOrderingConstraints {
+          expect("a").first()
+          expect("b").immediatelyAfterPrevious()
+          expect("b")
+          expect("c").last()
+        }
+    }
+  }
+
+  @Test
+  fun failsWithWrongFirstElement() {
+    assertThrows<AssertionError> {
+      expectThat(listOf("a", "b", "c"))
+        .containsWithOrderingConstraints {
+          expect("a")
+          expect("b").first()
+          expect("c")
+        }
+    }
+  }
+
+  @Test
+  fun failsWithWrongLastElement() {
+    assertThrows<AssertionError> {
+      expectThat(listOf("a", "b", "c"))
+        .containsWithOrderingConstraints {
+          expect("a")
+          expect("b").last()
+          expect("c")
+        }
+    }
+  }
+
+  @Test
+  fun firstAndLastInSections() {
+    expectThat(listOf("a", "b", "c", "d"))
+      .containsWithOrderingConstraints {
+        expect("a").first()
+        expect("b").last()
+        startNewSection()
+        expect("c").first()
+        expect("d").last()
+      }
+  }
+
+  @Test
+  fun wrongFirstInSecondSectionFails() {
+    assertThrows<AssertionError> {
+      expectThat(listOf("a", "b", "d", "c"))
+        .containsWithOrderingConstraints {
+          expect("a").first()
+          expect("b").last()
+          startNewSection()
+          expect("c").first()
+          expect("d")
+        }
+    }
+  }
+
+  @Test
+  fun wrongLastInSecondSectionFails() {
+    assertThrows<AssertionError> {
+      expectThat(listOf("a", "b", "d", "c"))
+        .containsWithOrderingConstraints {
+          expect("a").first()
+          expect("b").last()
+          startNewSection()
+          expect("c")
+          expect("d").last()
+        }
+    }
+  }
+}


### PR DESCRIPTION
I've come across a few test scenarios where I want to assert ordering on an iterable, but `contains`, `containsExactly`, and `containsExactlyInAnyOrder` don't quite cut it. Two particular cases that come to mind are asserting lifecycle callbacks and asserting connection state. What they have in common is that some aspects of their order matter, but not all.

I've generally gone about solving these cases by either mangling the result list before asserting on it (e.g. filtering or reordering elements), or creating a combinatorial explosion of valid results and asserting that the result is one of them. Both leave my tests a lot uglier than I'd like.

This is my take on an assertion builder for iterables that can assert fuzzy ordering rules.
The API is a block in which user asserts elements in the subject, and positional constraints for those elements.

Here's an example of its usage, illustrating my most recent use case:
```kotlin
enum class LifecycleCall { Created, Started, Stopped, Destroyed, Attached, Detached }

/**
 *  Assert that:
 *  - Created comes first
 *  - Destroyed comes last
 *  - In between Created and Destroyed, we get Started and Stopped
 *  - Attached comes after Created, but it doesn't matter if it's before or after Started
 *  - Detached comes before Destroyed, and after Attached,
 *    but it doesn't matter if it's before or after Stopped
 */
@Test
fun properLifecycleCallsAfterStartAndStop() {
  val result = thingWithLifecycle.collectLifecycleCalls()
  expectThat(result)
    .containsWithOrderingConstraints {
      expect(Created).first()
      expect(Started)
        .after(Created)
      expect(Attached)

      // About to stop
      expect(Detached)
        .after(Attached)
      expect(Stopped)
        .after(Started)
      expect(Destroyed).last()
    }
}
```

I realize this is a rather opinionated addition to the assertion library, so if this isn't a good fit, feel free to close.