### PR TITLE
Line separator

### DIFF
--- a/strikt-core/src/main/kotlin/strikt/internal/reporting/DefaultResultWriter.kt
+++ b/strikt-core/src/main/kotlin/strikt/internal/reporting/DefaultResultWriter.kt
@@ -172,7 +172,7 @@ internal open class DefaultResultWriter : ResultWriter {
     node: AssertionNode<*>
   ) {
     if (node is DescribedNode) {
-      writer.append(EOL)
+      writer.appendLine()
     }
   }
 
@@ -193,5 +193,3 @@ internal open class DefaultResultWriter : ResultWriter {
     writer.append("▼ ")
   }
 }
-
-private val EOL = System.lineSeparator()

--- a/strikt-core/src/main/kotlin/strikt/internal/reporting/DefaultResultWriter.kt
+++ b/strikt-core/src/main/kotlin/strikt/internal/reporting/DefaultResultWriter.kt
@@ -194,4 +194,4 @@ internal open class DefaultResultWriter : ResultWriter {
   }
 }
 
-private val EOL = System.getProperty("line.separator")
+private val EOL = System.lineSeparator()


### PR DESCRIPTION
Running on a Windows machine, any tests that check multi-line string equality fail:

![Screenshot 2025-06-11 163421](https://github.com/user-attachments/assets/56aaa971-8b05-4762-af18-64d963b93e3e)

These tests fail only due to a difference in line separators:

![Screenshot 2025-06-11 162957](https://github.com/user-attachments/assets/954a7b5b-fc95-498f-88da-c10620762083)

Even on Windows, even when the source code file itself contains CR/LF endings:

![image](https://github.com/user-attachments/assets/f8390065-43ec-4089-bbd4-5bde56a07fd0)

the internal structures used by Java contain just LF.

A small sanity check test:

```kotlin
val multiLine = """AA
AA"""
val lf = "AA\nAA"
val crlf = "AA\r\nAA"

fun String.bytes() = this.toByteArray().joinToString()

println(multiLine.bytes()) // 65, 65, 10, 65, 65
println(lf.bytes())        // 65, 65, 10, 65, 65
println(crlf.bytes())      // 65, 65, 13, 10, 65, 65
```

The actual multi-line strings contain just `\n` rather than `\r\n`.
